### PR TITLE
Include 'colors' module in dependencies

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -8,6 +8,7 @@ var path = require('path'),
     Mustache = require('mustache'),
     glob = require('glob'),
     md = require('../node_modules/reveal.js/plugin/markdown/markdown'),
+    colors = require('colors'),
     exec = require('child_process').exec;
 
 var app = express.createServer();

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mustache": "0.4.0",
     "open": "0.0.3",
     "glob": "3.2.1",
-    "commander": "1.2.0"
+    "commander": "1.2.0",
+    "colors": "0.6.2"
   }
 }


### PR DESCRIPTION
The absence of this module was causing an undefined error whenever --print-pdf option was being called.
