### PR TITLE
add highlight.js dependency for syntax highlighting

### DIFF
--- a/template/reveal.html
+++ b/template/reveal.html
@@ -37,6 +37,7 @@
                     { src: '/lib/js/classList.js', condition: function() { return !document.body.classList; } },
                     { src: '/plugin/markdown/marked.js', condition: function() { return !!document.querySelector('[data-markdown]'); } },
                     { src: '/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector('[data-markdown]'); } },
+                    { src: '/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
                     { src: '/plugin/notes/notes.js', async: true, condition: function() { return !!document.body.classList; } }
                 ]
             });


### PR DESCRIPTION
reveal.js supports code syntax highlighting via the hightlight.js library.
by declaring it as a dependency, syntax highlight just works.
