### PR TITLE
Allow to define custom theme

### DIFF
--- a/bin/server-cli.js
+++ b/bin/server-cli.js
@@ -10,7 +10,7 @@ var fs = require('fs'),
 var basePath = process.cwd(),
     baseName,
     filePath,
-    themePath = __dirname + '/../node_modules/reveal.js/css/theme',
+    revealPath = __dirname + '/../node_modules/reveal.js',
     theme = 'black';
 
 program
@@ -61,11 +61,13 @@ if(pathArg === 'demo') {
     }
 }
 
-theme = glob.sync('*.css', {
-    cwd: themePath
-}).map(function(themePath) {
-    return path.basename(themePath).replace(path.extname(themePath), '');
-}).indexOf(program.theme) !== -1 ? program.theme : theme;
+theme = glob.sync('css/theme/*.css', {
+    cwd: revealPath
+}).concat(glob.sync('theme/*.css', {
+  cwd: path.resolve('./')
+})).filter(function(themePath) {
+  return path.basename(themePath).replace(path.extname(themePath), '') === program.theme;
+}).pop() || 'css/theme/' + theme + '.css';
 
 // load custom reveal.js options from reveal.json
 var revealOptions = {};

--- a/template/listing.html
+++ b/template/listing.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <title>Directory Listing</title>
-        <link rel="stylesheet" href="/css/theme/{{theme}}.css" id="theme">
+        <link rel="stylesheet" href="/{{{theme}}}" id="theme">
         <style type="text/css">
             body {
                 margin: 1em;

--- a/template/reveal.html
+++ b/template/reveal.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <title>Reveal.js</title>
         <link rel="stylesheet" href="/css/reveal.css">
-        <link rel="stylesheet" href="/css/theme/{{theme}}.css" id="theme">
+        <link rel="stylesheet" href="/{{{theme}}}" id="theme">
         <!-- For syntax highlighting -->
         <link rel="stylesheet" href="/lib/css/zenburn.css">
 


### PR DESCRIPTION
I often use a custom (branded) theme.
This PR allows for custom themes.

It will first look at the reveal.js theme directory and then merges the custom themes in the list.
When no team matches the given name, if will fall back to black.css (as it used to do)