### PR TITLE
Added --highlightTheme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Override theme (default: `black`):
 reveal-md slides.md --theme solarized
 ```
 
+Override [highlight theme](https://github.com/isagalaev/highlight.js/tree/master/src/styles) (default: `zenburn`):
+
+``` bash
+reveal-md slides.md --highlightTheme github
+```
+
 Override slide separator (default: `\n---\n`):
 
 ``` bash

--- a/bin/server-cli.js
+++ b/bin/server-cli.js
@@ -11,7 +11,8 @@ var basePath = process.cwd(),
     baseName,
     filePath,
     revealPath = __dirname + '/../node_modules/reveal.js',
-    theme = 'black';
+    theme = 'black',
+    highlightTheme = 'zenburn';
 
 program
     .version(pkg.version)
@@ -19,6 +20,7 @@ program
     .option('-h, --host [host]', 'Host')
     .option('-p, --port [port]', 'Port')
     .option('-t, --theme [theme]', 'Theme')
+    .option('-H, --highlightTheme [highlight theme]', 'Highlight theme')
     .option('-r, --print [filename]', 'Print')
     .option('-s, --separator [separator]', 'Slide separator')
     .option('-v, --verticalSeparator [vertical separator]', 'Vertical slide separator')
@@ -69,6 +71,8 @@ theme = glob.sync('css/theme/*.css', {
   return path.basename(themePath).replace(path.extname(themePath), '') === program.theme;
 }).pop() || 'css/theme/' + theme + '.css';
 
+highlightTheme = program.highlightTheme || highlightTheme;
+
 // load custom reveal.js options from reveal.json
 var revealOptions = {};
 var manifestPath = path.join(basePath, 'reveal.json');
@@ -88,12 +92,18 @@ if (!program.theme && revealOptions.theme) {
   theme = revealOptions.theme;
 }
 
+// overide default highlight theme from manifest options
+if (!program.highlightTheme && revealOptions.highlightTheme) {
+  highlightTheme = revealOptions.highlightTheme;
+}
+
 server.start({
   basePath: basePath,
   initialMarkdownPath: baseName,
   host: program.host,
   port: program.port,
   theme: theme,
+  highlightTheme: highlightTheme,
   separator: program.separator,
   verticalSeparator: program.verticalSeparator,
   printFile: program.print,

--- a/bin/server.js
+++ b/bin/server.js
@@ -24,6 +24,7 @@ var opts = {
     template: fs.readFileSync(serverBasePath + '/template/reveal.html').toString(),
     templateListing: fs.readFileSync(serverBasePath + '/template/listing.html').toString(),
     theme: 'black',
+    highlightTheme: 'zenburn',
     separator: '^(\r\n?|\n)---(\r\n?|\n)$',
     verticalSeparator: '^(\r\n?|\n)----(\r\n?|\n)$',
     revealOptions: {}
@@ -44,12 +45,16 @@ var startMarkdownServer = function(options) {
     opts.host = options.host || opts.host;
     opts.port = options.port || opts.port;
     opts.theme = options.theme || opts.theme;
+    opts.highlightTheme = options.highlightTheme || opts.highlightTheme;
     opts.separator = options.separator || opts.separator;
     opts.verticalSeparator = options.verticalSeparator || opts.verticalSeparator;
     opts.printMode = typeof printFile !== 'undefined' && printFile || opts.printMode;
     opts.revealOptions = options.revealOptions || {};
 
     generateMarkdownListing();
+
+    app.use('/lib/css/' + opts.highlightTheme + '.css',
+      staticDir(serverBasePath + '/node_modules/highlight.js/styles/' + opts.highlightTheme + '.css'));
 
     app.get(/(\w+\.md)$/, renderMarkdownAsSlides);
     app.get('/', renderMarkdownFileListing);
@@ -128,6 +133,7 @@ var render = function(res, markdown) {
 
     res.send(Mustache.to_html(opts.template, {
         theme: opts.theme,
+        highlightTheme: opts.highlightTheme,
         slides: slides,
         options: JSON.stringify(opts.revealOptions, null, 2)
     }));

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mustache": "2.0.0",
     "open": "0.0.5",
     "glob": "5.0.3",
-    "commander": "2.7.1"
+    "commander": "2.7.1",
+    "highlight.js": "8.7.0"
   }
 }

--- a/template/reveal.html
+++ b/template/reveal.html
@@ -6,7 +6,7 @@
         <link rel="stylesheet" href="/css/reveal.css">
         <link rel="stylesheet" href="/{{{theme}}}" id="theme">
         <!-- For syntax highlighting -->
-        <link rel="stylesheet" href="/lib/css/zenburn.css">
+        <link rel="stylesheet" href="/lib/css/{{{highlightTheme}}}.css">
 
         <!-- If the query includes 'print-pdf', use the PDF print sheet -->
         <script>


### PR DESCRIPTION
I like reveal-md. But what I was missing was an option to change the highlight theme for code highlighting. This PR contains this feature.

Changes:
* README.MD: Added example how to use `--highlightTheme`.
* server-cli.js: Added option for `--highlightTheme`.
* server.js: Added highlightTheme option to rendering AND static references to highlightTheme CSS file.
* package.json: Added highlight.js dependency for all highlight theme CSS files (default distribution of reveal.js only contains `zenburn` theme). 
* reveal.html: added mustache for highlightTheme parameter
