### PR TITLE
Allow a url as theme parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Inject custom scripts into the page:
 reveal-md slides.md --scripts script.js,another-script.js
 ```
 
+Override reveal theme with a remote one (use rawgit.com because the url must allow cross-site access):
+```
+reveal-md slides.md --theme https://rawgit.com/puzzle/pitc-revealjs-theme/master/theme/puzzle.css
+```
+
 Override [highlight theme](https://github.com/isagalaev/highlight.js/tree/master/src/styles) (default: `zenburn`):
 
 ``` bash

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -69,14 +69,17 @@ if(pathArg === 'demo') {
     }
 }
 
-theme = glob.sync('css/theme/*.css', {
-    cwd: revealPath
-}).concat(glob.sync('theme/*.css', {
-    cwd: path.resolve(basePath)
-})).filter(function(themePath) {
-    return path.basename(themePath).replace(path.extname(themePath), '') === program.theme;
-}).pop() || 'css/theme/' + theme + '.css';
-
+if (program.theme && program.theme.match(/^http.*css$/)) {
+    theme = program.theme
+} else {
+    theme = glob.sync('css/theme/*.css', {
+        cwd: revealPath
+    }).concat(glob.sync('theme/*.css', {
+        cwd: path.resolve(basePath)
+    })).filter(function(themePath) {
+        return path.basename(themePath).replace(path.extname(themePath), '') === program.theme;
+    }).pop() || 'css/theme/' + theme + '.css';
+}
 highlightTheme = program.highlightTheme || highlightTheme;
 title = program.title || title;
 


### PR DESCRIPTION
This enables the use of a simple url for the --theme option. See #65  