### PR TITLE
Make `--scripts` option work (minimally) when generating static output

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -117,7 +117,10 @@ if(program.static) {
         separator: program.separator,
         verticalSeparator: program.verticalSeparator,
         printFile: program.print,
-        revealOptions: revealOptions
+        revealOptions: revealOptions,
+        scripts: (program.scripts || '').split(',').map(function(script) {
+            return script[0] === '/' ? script : path.resolve(process.cwd(), script);
+        })
     });
 } else {
     server.start({

--- a/bin/server.js
+++ b/bin/server.js
@@ -199,7 +199,8 @@ var to_html = function(options) {
             highlightTheme: opts.highlightTheme,
             title: opts.title,
             slides: slides,
-            options: JSON.stringify(opts.revealOptions, null, 2)
+            options: JSON.stringify(opts.revealOptions, null, 2),
+            scripts: Object.keys(opts.scripts)
         });
 
         console.log(html);


### PR DESCRIPTION
This PR causes the `--scripts` option to basically behave the same way as usual when generating static output. 

When no scripts are defined, this is just a quick fix for #69 , meaning that `--static` no longer throws an error. 

When scripts are specified, the static HTML will declare tags for them, assuming them to live in `/scripts/`. The user will need to manually copy the files to such a folder (same as they need to copy all the other reveal-related files).