### PR TITLE
Introduce live-reloading or watch feature.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,7 @@ var basePath = process.cwd(),
     revealPath = path.resolve(require.resolve('reveal.js'), '..', '..'),
     theme = 'black',
     highlightTheme = 'zenburn',
+	watch = false,
     title;
 
 program
@@ -27,6 +28,7 @@ program
     .option('-s, --separator [separator]', 'Slide separator')
     .option('-v, --verticalSeparator [vertical separator]', 'Vertical slide separator')
     .option('-i, --scripts [list of scripts]', 'Scripts to inject into the page')
+	.option('-w, --watch', 'Watch for changes in markdown file and livereload presentation')
     .option('--disableAutoOpen', 'Disable to automatically open your web browser')
     .option('--static', 'Export static html to stdout. Save to reveal.js/index.html to' +
         ' match dependencies. HINT: printing does not work properly in this mode')
@@ -107,6 +109,10 @@ if(!program.highlightTheme && revealOptions.highlightTheme) {
     highlightTheme = revealOptions.highlightTheme;
 }
 
+if(program.watch) {
+	watch = true;
+}
+
 if(program.static) {
     server.toStaticHTML({
         basePath: basePath,
@@ -138,7 +144,8 @@ if(program.static) {
         openWebBrowser: !program.disableAutoOpen,
         scripts: (program.scripts || '').split(',').map(function(script) {
             return script[0] === '/' ? script : path.resolve(process.cwd(), script);
-        })
+        }),
+		watch: watch
     });
 }
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -29,7 +29,8 @@ var opts = {
     separator: '^(\r\n?|\n)---(\r\n?|\n)$',
     verticalSeparator: '^(\r\n?|\n)----(\r\n?|\n)$',
     revealOptions: {},
-    scripts: {}
+    scripts: {},
+	watch: false
 };
 
 var printPluginPath = path.join(serverBasePath, 'node_modules', 'reveal.js', 'plugin', 'print-pdf', 'print-pdf.js');
@@ -50,7 +51,7 @@ var fillOpts = function(options) {
     opts.printMode = typeof options.printFile !== 'undefined' && options.printFile || opts.printMode;
     opts.revealOptions = options.revealOptions || {};
     opts.openWebBrowser = options.openWebBrowser;
-
+	opts.watch = options.watch || opts.watch;
     opts.scripts = {};
     options.scripts.forEach(function(script) {
         opts.scripts[path.basename(script)] = script;
@@ -66,6 +67,14 @@ var startMarkdownServer = function(options) {
 
     app.use('/lib/css/' + opts.highlightTheme + '.css',
         staticDir(path.join(serverBasePath, 'node_modules', 'highlight.js', 'styles', opts.highlightTheme + '.css')));
+
+	if(opts.watch) {
+		var livereload = require('livereload');
+		var liveReloadServer = livereload.createServer({
+			exts: ['md']
+		});
+		liveReloadServer.watch(opts.userBasePath);
+	}
 
     app.get(/(\w+\.md)$/, renderMarkdownAsSlides);
     app.get('/scripts/*', getScript);
@@ -110,6 +119,7 @@ var startMarkdownServer = function(options) {
             open(initialFilePath);
         }
     }
+
 };
 
 var renderMarkdownAsSlides = function(req, res) {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "reveal-md": "bin/cli.js"
   },
   "dependencies": {
-    "reveal.js": "3.2.0",
+    "commander": "2.9.0",
     "express": "4.13.4",
+    "glob": "7.0.0",
+    "highlight.js": "9.2.0",
+    "livereload": "^0.5.0",
     "mustache": "2.2.1",
     "open": "0.0.5",
-    "glob": "7.0.0",
-    "commander": "2.9.0",
-    "highlight.js": "9.2.0"
+    "reveal.js": "3.2.0"
   }
 }

--- a/template/reveal.html
+++ b/template/reveal.html
@@ -12,6 +12,10 @@
         <script>
           document.write( '<link rel="stylesheet" href="css/print/' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
         </script>
+		<script>
+		  document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] +
+		  ':35729/livereload.js?snipver=1"></' + 'script>')
+		</script>
     </head>
     <body>
 
@@ -63,7 +67,7 @@
             options = extend(defaultOptions, options, queryOptions);
             Reveal.initialize(options);
         </script>
-        
+
         {{#scripts}}
           <script src="/scripts/{{.}}"></script>
         {{/scripts}}


### PR DESCRIPTION
Using `-w` option changes to markdown files will trigger the browser to
reload and thus display the changed presentation without the user having
to reload the browser.

The only problem I see is that a piece of script gets added to the `reveal.html` template

``` html
<script>
  document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] +
  ':35729/livereload.js?snipver=1"></' + 'script>')
</script>
```

That should really not always be there but be added conditionally. Though I didn't quite get how scripts are injected. But I feel like adding this to the injected scripts when `options.watch === true` would be the way to go.

This would address #63. 
