### PR TITLE
Make `scripts/` link relative

### DIFF
--- a/template/reveal.html
+++ b/template/reveal.html
@@ -65,7 +65,7 @@
         </script>
         
         {{#scripts}}
-          <script src="/scripts/{{.}}"></script>
+          <script src="scripts/{{.}}"></script>
         {{/scripts}}
     </body>
 </html>


### PR DESCRIPTION
This changes the custom `script.js` in the slide template to be relative. This allows static output to be served from a non-root folder (e.g. when using gh-pages).

I've not done any crazy testing but both serving and static builds work for me. And all the other links in the template are relative, so I'm guessing it's safe?

Fixes #74 

Thanks!
