### PR TITLE
Add support for YAML front matter in md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,31 @@ Disable to automatically open your web browser:
 reveal-md slides.md --disableAutoOpen
 ```
 
+## YAML Front matter
+
+You can set markdown options and revealoptions specific to your pressentation in the .md file with YAML
+front matter header Jekyll style.
+
+```
+---
+title: Foobar
+separator: <!--s-->
+verticalSeparator: <!--v-->
+theme: css/theme/solarized.css
+revealOptions:
+    transition: 'fade'
+---
+Foo
+
+Note: test note
+
+<!--s-->
+
+# Bar
+
+<!--v-->
+```   
+
 ## Print Support
 
 *Requires phantomjs to be installed (preferably globally)*

--- a/bin/server.js
+++ b/bin/server.js
@@ -114,10 +114,13 @@ var startMarkdownServer = function(options) {
 
 var renderMarkdownAsSlides = function(req, res) {
 
-    var markdown = '',
+    var document = "",
+        markdown = '',
         markdownPath,
         fsPath;
 
+    var yamlFrontMatter = require('yaml-front-matter');
+    
     // Look for print-pdf option
     if(~req.url.indexOf('?print-pdf')) {
         req.url = req.url.replace('?print-pdf', '');
@@ -128,7 +131,12 @@ var renderMarkdownAsSlides = function(req, res) {
     fsPath = markdownPath.replace(/(\?.*)$/, '');
 
     if(fs.existsSync(fsPath)) {
-        markdown = fs.readFileSync(fsPath).toString();
+        document = yamlFrontMatter.loadFront(fs.readFileSync(fsPath).toString());
+        markdown = (document.__content)?document.__content:document;
+        var prop;
+        for(prop in document){
+            opts[prop] = document[prop];
+        }
         render(res, markdown);
     } else {
         var parsedUrl = url.parse(req.url.replace(/^\//, ''));

--- a/bin/server.js
+++ b/bin/server.js
@@ -8,7 +8,8 @@ var path = require('path'),
     Mustache = require('mustache'),
     glob = require('glob'),
     md = require('reveal.js/plugin/markdown/markdown'),
-    exec = require('child_process').exec;
+    exec = require('child_process').exec,
+    yamlFrontMatter = require('yaml-front-matter');
 
 var app = express();
 var staticDir = express.static;
@@ -117,10 +118,8 @@ var renderMarkdownAsSlides = function(req, res) {
     var document = {},
         markdown = '',
         markdownPath,
-        fsPath;
-        
-
-    var yamlFrontMatter = require('yaml-front-matter');
+        fsPath,
+        prop;
     
     // Look for print-pdf option
     if(~req.url.indexOf('?print-pdf')) {
@@ -128,18 +127,17 @@ var renderMarkdownAsSlides = function(req, res) {
     }
 
     markdownPath = path.resolve(opts.userBasePath + req.url);
-
     fsPath = markdownPath.replace(/(\?.*)$/, '');
 
     if(fs.existsSync(fsPath)) {
-        document = yamlFrontMatter.loadFront(fs.readFileSync(fsPath).toString());
-        markdown = (document.__content)?document.__content:document;
-        var prop;
+        document = yamlFrontMatter.loadFront( fs.readFileSync( fsPath ).toString() );
+        markdown = (document.__content)? document.__content : document;
         for(prop in opts){
-            if(!document.hasOwnProperty(prop)){
-                document[prop] = opts[prop];
+            if ( !document.hasOwnProperty( prop ) ){
+                document[ prop ] = opts[ prop ];
             }
         }
+
         render(res, markdown, document);
     } else {
         var parsedUrl = url.parse(req.url.replace(/^\//, ''));

--- a/demo/c.md
+++ b/demo/c.md
@@ -1,0 +1,20 @@
+---
+title: Foobar
+separator: <!--slide-->
+verticalSeparator: <!--vertical-->
+---
+Foo
+
+Note: test note
+
+<!--slide-->
+
+Bar
+
+<!--vertical-->
+
+Sub Bar
+
+<!--slide-->
+
+The End.

--- a/demo/c.md
+++ b/demo/c.md
@@ -1,20 +1,24 @@
 ---
 title: Foobar
-separator: <!--slide-->
-verticalSeparator: <!--vertical-->
+separator: <!--s-->
+verticalSeparator: <!--v-->
+theme: css/theme/solarized.css
 ---
 Foo
 
 Note: test note
 
-<!--slide-->
+<!--s-->
 
-Bar
+# Bar
 
-<!--vertical-->
+<!--v-->
 
-Sub Bar
+Sub Bar 
 
-<!--slide-->
+* Frag 1 <!-- .element: class="fragment" -->
+* Frag 2 <!-- .element: class="fragment" -->
+
+<!--s-->
 
 The End.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "open": "0.0.5",
     "glob": "7.0.0",
     "commander": "2.9.0",
-    "highlight.js": "9.2.0"
+    "highlight.js": "9.2.0",
+    "yaml-front-matter": "^3.4.0"
   }
 }


### PR DESCRIPTION
I Added the ability to set options in the .md file in jekyll style with YAML frontmatter like this
```
---
title: Foobar
separator: <!--s-->
verticalSeparator: <!--v-->
theme: css/theme/solarized.css
---
Foo

Note: test note

<!--s-->

# Bar

<!--v-->
```