### PR TITLE
add a markdown preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,39 @@ This slide has no background image.
 This one does!
 ```
 
+## Markdown preprocessor
+
+`reveal-md` can be given a markdown preprocessor script via the `--preprocessor` (or
+`-P`) option. This can be useful to implement custom tweaks on the document
+format without having to dive into the guys of the Markdown parser.
+
+For example, to have headers automatically create new slides, one could have
+the script `preproc.js`:
+
+```javascript
+// headings trigger a new slide
+// headings with a caret (e.g., '##^ foo`) trigger a new vertical slide
+module.exports = (mkd,opt) => 
+    mkd.split( "\n" )
+        .map( line => {
+            if ( ! /^#/.test(line) ) return line;
+
+            var is_vertical = /#\^/.test(line);
+
+            return ( 
+                is_vertical ? "\n\n<!--v-->\n\n" : "\n\n---\n\n"
+            ) + line.replace( '#^', '#' );
+        })
+        .join("\n");
+```
+
+and use it like this
+
+```bash
+$ reveal-md -P preproc.js slides.md
+```
+
+
 ## Notes
 
 * `reveal-md` always starts a local server and opens the default browser

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,6 +28,7 @@ program
     .option('-v, --verticalSeparator [vertical separator]', 'Vertical slide separator')
     .option('-i, --scripts [list of scripts]', 'Scripts to inject into the page')
     .option('--disableAutoOpen', 'Disable to automatically open your web browser')
+    .option('-P, --preprocessor [script]', 'Preprocessor script')
     .option('--static', 'Export static html to stdout. Save to reveal.js/index.html to' +
         ' match dependencies. HINT: printing does not work properly in this mode')
     .parse(process.argv);
@@ -122,7 +123,8 @@ if(program.static) {
         verticalSeparator: program.verticalSeparator,
         printFile: program.print,
         revealOptions: revealOptions,
-        scripts: scripts
+        scripts: scripts,
+        preprocessor: program.preprocessor
     });
 } else {
     server.start({
@@ -138,7 +140,8 @@ if(program.static) {
         printFile: program.print,
         revealOptions: revealOptions,
         openWebBrowser: !program.disableAutoOpen,
-        scripts: scripts
+        scripts: scripts,
+        preprocessor: program.preprocessor
     });
 }
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -52,6 +52,11 @@ var fillOpts = function(options) {
     opts.revealOptions = options.revealOptions || {};
     opts.openWebBrowser = options.openWebBrowser;
 
+    // if there is no preprocessor, create a passthu function
+    opts.preprocessor 
+        = options.preprocessor ? require( serverBasePath + '/' + options.preprocessor )
+                               : function(raw_text) { return raw_text };
+
     opts.scripts = {};
     options.scripts.forEach(function(script) {
         opts.scripts[path.basename(script)] = script;
@@ -165,6 +170,7 @@ var render = function(res, markdown, renderOptions) {
     var slides;
     if(!renderOptions)
     renderOptions = renderOptions ? renderOptions : opts;
+    markdown = opts.preprocessor(markdown,renderOptions);
     slides = md.slidify(markdown, renderOptions);
 
     res.send(Mustache.to_html(renderOptions.template, {


### PR DESCRIPTION
allows for a script to groom the markdown before being fed to marked and revealjs. I find it useful to quickly (and dirtily) implement custom shorthands.