### PR TITLE
copy scripts file to static html export target scripts directory

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -66,7 +66,10 @@ function parseScriptsArg(scripts) {
 }
 
 function parseScriptsPath(scripts) {
-  return (typeof scripts === 'string' ? scripts.split(',') : []).map(script => path.resolve(process.cwd(), script));
+  return (typeof scripts === 'string' ? scripts.split(',') : []).map(script => ({
+    path: path.resolve(process.cwd(), script),
+    name: script
+  }));
 }
 
 function parsePreprocessorArg(preprocessor) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -65,6 +65,10 @@ function parseScriptsArg(scripts) {
   return (typeof scripts === 'string' ? scripts.split(',') : []).map(script => path.join('scripts', script));
 }
 
+function parseScriptsPath(scripts) {
+  return (typeof scripts === 'string' ? scripts.split(',') : []).map(script => path.resolve(process.cwd(), script));
+}
+
 function parsePreprocessorArg(preprocessor) {
   return preprocessor ? require(path.join(process.cwd(), preprocessor)) : _.identity;
 }
@@ -94,6 +98,7 @@ function parseOptions(args) {
 
   options.themePath = parseThemeArg(args.theme || defaults.theme);
   options.scriptPaths = parseScriptsArg(args.scripts);
+  options.scriptSources = parseScriptsPath(args.scripts);
   options.title = args.title || defaults.title;
   options.separator = args.separator || defaults.separator;
   options.verticalSeparator = args.verticalSeparator || defaults.verticalSeparator;

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,8 +1,7 @@
 const fs = require('fs-extra'),
   path = require('path'),
   render = require('./render').render,
-  _ = require('lodash'),
-  shell = require('shelljs');
+  _ = require('lodash');
 
 module.exports = function renderStaticMarkup(options) {
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -24,8 +24,9 @@ module.exports = function renderStaticMarkup(options) {
 
   if(!_.isEmpty(options.scripts)) {
     const scriptsDir = path.join(targetPath, 'scripts');
-    shell.mkdir('-p', scriptsDir);
-    shell.cp(options.scriptSources, scriptsDir);
+    fs.ensureDirSync(scriptsDir);
+    const scriptsAwait = options.scriptSources.map(scriptFile => fs.copyAsync(scriptFile.path, path.join(scriptsDir, scriptFile.name)));
+    awaits.push(scriptsAwait);
   }
 
   Promise.all(awaits).then(() => console.log(`Wrote static site to ${targetPath}`)).catch(console.error);

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,6 +1,8 @@
 const fs = require('fs-extra'),
   path = require('path'),
-  render = require('./render').render;
+  render = require('./render').render,
+  _ = require('lodash'),
+  shell = require('shelljs');
 
 module.exports = function renderStaticMarkup(options) {
 
@@ -19,6 +21,12 @@ module.exports = function renderStaticMarkup(options) {
 
   awaits.push(markupAwait);
   awaits.push(highlightAwait);
+
+  if(!_.isEmpty(options.scripts)) {
+    const scriptsDir = path.join(targetPath, 'scripts');
+    shell.mkdir('-p', scriptsDir);
+    shell.cp(options.scriptSources, scriptsDir);
+  }
 
   Promise.all(awaits).then(() => console.log(`Wrote static site to ${targetPath}`)).catch(console.error);
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "mustache": "2.3.0",
     "open": "0.0.5",
     "reveal.js": "3.4.1",
+    "shelljs": "^0.7.7",
     "yaml-front-matter": "^3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "mustache": "2.3.0",
     "open": "0.0.5",
     "reveal.js": "3.4.1",
-    "shelljs": "^0.7.7",
     "yaml-front-matter": "^3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change will make static html export files contain the injected scripts, and copy these script files  into `${targetDir}/scripts/${injectedScript}`
Such as:
```
reveal-md demo/a.md --static ./build -i ./test.js
```
will get like
```
build/
  ...
  - index.html
  - scripts/
    - test.js
```

