### PR TITLE
Add Support for custom style and a reveal-md.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ reveal-md demo
 * YAML Front Matter
 * Live Reload
 * Custom Scripts
+* Custom CSS
 * Pre-process Markdown
 * Print to PDF
 * Static Website
@@ -150,7 +151,7 @@ You can define Reveal-md options similar to command-line options in a `reveal-md
 ``` json
 {
   "separator": "^\n\n\n",
-  "verticalSeparator: "^\n\n"
+  "verticalSeparator": "^\n\n"
 }
 ```
 
@@ -195,6 +196,14 @@ Inject custom scripts into the page:
 
 ``` bash
 reveal-md slides.md --scripts script.js,another-script.js
+```
+
+### Custom CSS
+
+Inject custom CSS into the page:
+
+``` bash
+reveal-md slides.md --css style.css,another-style.css
 ```
 
 ### Pre-process Markdown

--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ You can define Reveal.js [options](https://github.com/hakimel/reveal.js#configur
 }
 ```
 
+### Reveal-md Options
+
+You can define Reveal-md options similar to command-line options in a `reveal-md.json` file that you should put in the root directory of the Markdown files. They'll be picked up automatically. Example:
+
+``` json
+{
+  "separator": "^\n\n\n",
+  "verticalSeparator: "^\n\n"
+}
+```
+
 ### Speaker Notes
 
 You can use the [speaker notes](https://github.com/hakimel/reveal.js#speaker-notes) feature by using a line starting with `Note:`.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12,6 +12,7 @@ program
   .option('-H, --highlight-theme <theme>', `Highlight theme [${defaults.highlightTheme}]`, defaults.highlightTheme)
   .option('-h, --host <host>', `Host [${defaults.host}]`, defaults.host)
   .option('-i, --scripts <scripts>', 'Scripts to inject into the page', defaults.scripts)
+  .option('-c, --css <css>', 'CSS files to inject into the page', defaults.css)
   .option('-m, --preprocessor <script>', 'Markdown preprocessor script', defaults.preprocessor)
   .option('-p, --port <port>', `Port [${defaults.port}]`, defaults.port)
   .option('-P, --print [filename]', 'Print', defaults.print)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const program = require('commander'),
-  defaults = require('../lib/defaults'),
+  defaults = require('../lib/options').getDefaults(),
   revealMarkdown = require('./../lib'),
   pkg = require('../package.json');
 
@@ -9,18 +9,18 @@ program
   .version(pkg.version)
   .usage('<slides.md> [options]')
   .option('-D, --disable-auto-open', 'Disable auto-opening your web browser', defaults.disableAutoOpen)
-  .option('-H, --highlight-theme <theme>', 'Highlight theme [zenburn]', defaults.highlightTheme)
-  .option('-h, --host <host>', 'Host [localhost]', defaults.host)
+  .option('-H, --highlight-theme <theme>', `Highlight theme [${defaults.highlightTheme}]`, defaults.highlightTheme)
+  .option('-h, --host <host>', `Host [${defaults.host}]`, defaults.host)
   .option('-i, --scripts <scripts>', 'Scripts to inject into the page', defaults.scripts)
   .option('-m, --preprocessor <script>', 'Markdown preprocessor script', defaults.preprocessor)
-  .option('-p, --port <port>', 'Port [1948]', defaults.port)
+  .option('-p, --port <port>', `Port [${defaults.port}]`, defaults.port)
   .option('-P, --print [filename]', 'Print', defaults.print)
-  .option('-t, --theme <theme>', 'Theme [black]', defaults.theme)
+  .option('-t, --theme <theme>', `Theme [${defaults.theme}]`, defaults.theme)
   .option('-T, --title <title>', 'Title of the presentation', defaults.title)
   .option('-s, --separator <separator>', 'Slide separator', defaults.separator)
-  .option('-S, --static [dir]', 'Export static html to directory [_static]. Incompatible with --print.', defaults.static)
+  .option('-S, --static [dir]', `Export static html to directory [${typeof defaults.static === 'string' ? defaults.static : '_static'}]. Incompatible with --print.`, defaults.static)
   .option('-v, --vertical-separator <separator>', 'Vertical slide separator', defaults.verticalSeparator)
-  .option('-w, --watch', 'Watch for changes in markdown file and livereload presentation [false]', defaults.watch)
+  .option('-w, --watch', `Watch for changes in markdown file and livereload presentation [${defaults.watch}]`, defaults.watch)
   .parse(process.argv);
 
 if(program.args.length > 2) {

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -3,6 +3,7 @@
   "highlightTheme": "zenburn",
   "host": "localhost",
   "scripts": [],
+  "css": [],
   "preprocessor": false,
   "port": 1948,
   "print": false,

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,7 +3,15 @@ const fs = require('fs'),
   glob = require('glob'),
   url = require('url'),
   _ = require('lodash'),
-  defaults = require('./defaults.json');
+  debug = require('debug')('reveal-md');
+  
+let defaults = require('./defaults.json');
+try {
+  defaults = _.extend({}, defaults, require(path.join(process.cwd(), 'reveal-md.json')));
+} catch(err) {
+  debug(err.message);
+}
+
 
 const revealBasePath = path.resolve(require.resolve('reveal.js'), '..', '..');
 const highlightThemePath = path.resolve(require.resolve('highlight.js'), '..', '..', 'styles');
@@ -15,6 +23,10 @@ const templateListing = fs.readFileSync(templateListingPath).toString();
 const revealThemes = glob.sync('css/theme/*.css', {cwd: revealBasePath});
 const localThemes = glob.sync('theme/*.css', {cwd: process.cwd()});
 const availableThemes = revealThemes.concat(localThemes);
+
+function getDefaults() {
+  return defaults;
+}
 
 function parsePath(pathArg, baseDir) {
   const opts = {};
@@ -122,6 +134,7 @@ function parseOptions(args) {
 }
 
 module.exports = {
+  getDefaults,
   parsePath,
   parseOptions
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -97,6 +97,7 @@ const optionList = [
   'preprocessor',
   'revealOptions',
   'scripts',
+  'css',
   'separator',
   'static',
   'theme',
@@ -114,6 +115,8 @@ function parseOptions(args) {
   options.themePath = parseThemeArg(args.theme || defaults.theme);
   options.scriptPaths = parseScriptsArg(args.scripts);
   options.scriptSources = parseScriptsPath(args.scripts);
+  options.cssPaths = parseScriptsArg(args.css);
+  options.cssSources = parseScriptsPath(args.css);
   options.title = args.title || defaults.title;
   options.separator = args.separator || defaults.separator;
   options.verticalSeparator = args.verticalSeparator || defaults.verticalSeparator;

--- a/lib/options.js
+++ b/lib/options.js
@@ -62,7 +62,7 @@ function parseThemeArg(theme) {
 }
 
 function parseScriptsArg(scripts) {
-  return (typeof scripts === 'string' ? scripts.split(',') : []).map(script => path.join('scripts', script));
+  return (typeof scripts === 'string' ? scripts.split(',') : []).map(script => `scripts/${script}`);
 }
 
 function parseScriptsPath(scripts) {

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -33,7 +33,7 @@ module.exports = function startServer(options, cb) {
     app.use('/' + dir, staticDir(path.join(options.revealBasePath, dir)));
   });
 
-  app.use(`/css/highlight`, staticDir(options.highlightThemePath));
+  app.use('/css/highlight', staticDir(options.highlightThemePath));
 
   if(options.watch) {
     const liveReloadServer = liveReload.createServer({

--- a/lib/static.js
+++ b/lib/static.js
@@ -28,6 +28,13 @@ module.exports = function renderStaticMarkup(options) {
     awaits.concat(scriptAwaits);
   }
 
+  if(!_.isEmpty(options.css)) {
+    const scriptsDir = path.join(targetPath, 'scripts');
+    fs.ensureDirSync(scriptsDir);
+    const scriptAwaits = options.cssSources.map(scriptFile => fs.copyAsync(scriptFile.path, path.join(scriptsDir, scriptFile.name)));
+    awaits.concat(scriptAwaits);
+  }
+
   Promise.all(awaits).then(() => console.log(`Wrote static site to ${targetPath}`)).catch(console.error);
 
 };

--- a/lib/template/reveal.html
+++ b/lib/template/reveal.html
@@ -7,6 +7,9 @@
         <link rel="stylesheet" href="{{{themeUrl}}}" id="theme">
         <link rel="stylesheet" href="{{{highlightThemeUrl}}}">
         <link rel="stylesheet" href="{{{base}}}/css/print/{{#print}}pdf{{/print}}{{^print}}paper{{/print}}.css" type="text/css" media="print">
+        {{#cssPaths}}
+          <link rel="stylesheet" href="{{{base}}}/{{{.}}}">
+        {{/cssPaths}}
 
         {{#watch}}
 		<script>

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -29,6 +29,18 @@ describe('render', () => {
     expect(actual).toInclude('<script src="./scripts/also.js"></script>');
   });
 
+  it('should render custom css after theme', () => {
+    const actual = render.render('# header', {css: 'style1.css,style2.css'});
+    const themeLink = '<link rel="stylesheet" href="./css/highlight/zenburn.css">';
+    const style1Link = '<link rel="stylesheet" href="./scripts/style1.css">';
+    const style2Link = '<link rel="stylesheet" href="./scripts/style2.css">';
+    expect(actual).toInclude(themeLink);
+    expect(actual).toInclude(style1Link);
+    expect(actual).toInclude(style2Link);
+    expect(actual.indexOf(style1Link)).toBeGreaterThan(actual.indexOf(themeLink))
+    expect(actual.indexOf(style2Link)).toBeGreaterThan(actual.indexOf(style1Link))
+  });
+
   it('should render print stylesheet', () => {
     const actual = render.render('', {print: true});
     expect(actual).toInclude('<link rel="stylesheet" href="./css/print/pdf.css" type="text/css" media="print">');


### PR DESCRIPTION
This will add:

* Custom styles as requested in Issue #94 (option selected to be -c, --css to not conflict with --separator or --static)
* Support for a reveal-md.json which stores reveal-md options with markdown files similar to reveal.json