### PR TITLE
Inline pictures as base64 dataUri for static site

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -7,6 +7,7 @@ const fs = require('fs-extra'),
   md = require('reveal.js/plugin/markdown/markdown'),
   _ = require('lodash'),
   parseOptions = require('./options').parseOptions;
+  imageDataURI = require('image-data-uri');
 
 function parseYamlFrontMatter(content) {
   const document = yamlFrontMatter.loadFront(content);
@@ -34,6 +35,28 @@ function parseSlides(markdown, options) {
     view,
     slides: md.slidify(processedMarkdown, slidifyOptions)
   };
+}
+
+function inlinePictures(markdown){
+  const regex = /!\[.*?\]\((.*?)\)/gi;
+  const images = markdown.match(regex)||[];
+  let promises = [];
+  images.forEach((match)=>{
+    let parts = [];
+    parts.push(match.match(/^!\[.*?\]/gi));
+    parts.push(match.match(/\]\((.*?)\)$/gi));
+    let href = parts[1][0].substring(2, parts[1][0].length - 1);
+    promises.push(imageDataURI.encodeFromFile(href).then(datauri=>{
+      markdown = markdown.replace(match,parts[0]+"("+datauri+")");
+    },err=>{
+      console.log("Not inlined: "+ match);
+  }))});
+
+  return new Promise((resolve,reject)=>{
+    Promise.all(promises).then(()=>{
+        resolve(markdown);
+      })
+  });
 }
 
 function render(markdown, options) {
@@ -82,5 +105,6 @@ module.exports = {
   render,
   renderMarkdownAsSlides,
   renderMarkdownFileListing,
-  parseSlides
+  parseSlides,
+  inlinePictures
 };

--- a/lib/render.js
+++ b/lib/render.js
@@ -7,7 +7,7 @@ const fs = require('fs-extra'),
   md = require('reveal.js/plugin/markdown/markdown'),
   _ = require('lodash'),
   parseOptions = require('./options').parseOptions;
-  imageDataURI = require('image-data-uri');
+ 
 
 function parseYamlFrontMatter(content) {
   const document = yamlFrontMatter.loadFront(content);
@@ -37,27 +37,6 @@ function parseSlides(markdown, options) {
   };
 }
 
-function inlinePictures(markdown){
-  const regex = /!\[.*?\]\((.*?)\)/gi;
-  const images = markdown.match(regex)||[];
-  let promises = [];
-  images.forEach((match)=>{
-    let parts = [];
-    parts.push(match.match(/^!\[.*?\]/gi));
-    parts.push(match.match(/\]\((.*?)\)$/gi));
-    let href = parts[1][0].substring(2, parts[1][0].length - 1);
-    promises.push(imageDataURI.encodeFromFile(href).then(datauri=>{
-      markdown = markdown.replace(match,parts[0]+"("+datauri+")");
-    },err=>{
-      console.log("Not inlined: "+ match);
-  }))});
-
-  return new Promise((resolve,reject)=>{
-    Promise.all(promises).then(()=>{
-        resolve(markdown);
-      })
-  });
-}
 
 function render(markdown, options) {
 
@@ -105,6 +84,5 @@ module.exports = {
   render,
   renderMarkdownAsSlides,
   renderMarkdownFileListing,
-  parseSlides,
-  inlinePictures
+  parseSlides
 };

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra'),
   path = require('path'),
   render = require('./render').render,
+  inlinePictures = require('./render').inlinePictures
   _ = require('lodash');
 
 module.exports = function renderStaticMarkup(options) {
@@ -14,6 +15,7 @@ module.exports = function renderStaticMarkup(options) {
   const awaits = ['css', 'js', 'plugin', 'lib'].map(dir => fs.copyAsync(path.join(options.revealBasePath, dir), path.join(targetPath, dir)));
 
   const markupAwait = fs.readFileAsync(options.relativePath)
+    .then(markdown => inlinePictures(markdown.toString(), options))
     .then(markdown => render(markdown.toString(), options))
     .then(markdown => fs.outputFileAsync(path.join(targetPath, 'index.html'), markdown));
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra'),
   path = require('path'),
   render = require('./render').render,
-  inlinePictures = require('./render').inlinePictures
+  imageDataURI = require('image-data-uri'),
   _ = require('lodash');
 
 module.exports = function renderStaticMarkup(options) {
@@ -15,7 +15,7 @@ module.exports = function renderStaticMarkup(options) {
   const awaits = ['css', 'js', 'plugin', 'lib'].map(dir => fs.copyAsync(path.join(options.revealBasePath, dir), path.join(targetPath, dir)));
 
   const markupAwait = fs.readFileAsync(options.relativePath)
-    .then(markdown => inlinePictures(markdown.toString(), options))
+    .then(markdown => embedImages(markdown.toString(), options))
     .then(markdown => render(markdown.toString(), options))
     .then(markdown => fs.outputFileAsync(path.join(targetPath, 'index.html'), markdown));
 
@@ -39,3 +39,28 @@ module.exports = function renderStaticMarkup(options) {
   Promise.all(awaits).then(() => console.log(`Wrote static site to ${targetPath}`)).catch(console.error);
 
 };
+
+function embedImages(markdown){
+  const mdImgRegex = /!\[.*?\]\((.*?)\)/gi;
+  const images = markdown.match(mdImgRegex)||[];
+  let allPromises = [];
+  images.forEach((match)=>{
+    
+    let imgTextPart = match.match(/^!\[.*?\]/gi);
+    let imgPathPart = match.match(/\]\((.*?)\)$/gi);
+    let href = imgPathPart[0].substring(2, imgPathPart[0].length - 1);
+    
+    allPromises.push(imageDataURI.encodeFromFile(href).then(datauri=>{
+      markdown = markdown.replace(match,imgTextPart+'('+datauri+')');
+    },()=>{
+      //console.log("Not inlined: "+ match);
+    }));
+  });
+
+  return new Promise((resolve)=>{
+    Promise.all(allPromises).then(()=>{
+      resolve(markdown);
+    });
+  });
+}
+

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "glob": "7.1.1",
     "got": "^6.7.1",
     "highlight.js": "9.9.0",
+    "image-data-uri": "^1.0.0",
     "livereload": "^0.6.0",
     "lodash": "^4.17.4",
     "mustache": "2.3.0",


### PR DESCRIPTION
Right now pictures on the local filesystem that is referenced from the md file  are not working well with the static site generated. They must be copied manually.

To get images referenced in the md file from the local filesystem to work automaticly with the static site  i have added functionality to inline them as base64 datauri:s   in the generated index.html

