### PR TITLE
Remove hostname and port from rendered resource

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -114,7 +114,7 @@ function parseOptions(args) {
   options.revealBasePath = revealBasePath;
   options.highlightThemePath = highlightThemePath;
 
-  options.base = () => options.host && options.port && !options.static ? `//${options.host}:${options.port}` : '.';
+  options.base = () => options.static ? '.' : '';
   options.template = () => template;
   options.templateListing = () => templateListing;
   options.themeUrl = () => getThemeUrl(options);


### PR DESCRIPTION
Remove configuration provided hostname and port from rendered resource paths as they will prevent reverse proxy usage and are superfluous.

It is not needed for the resource rendering to include the hostname and port, it actually prevents meaningful usage of reverse proxies (like for SSL offloading) and it increases configuration workarounds.