### PR TITLE
Fix handling of static files

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -45,7 +45,7 @@ module.exports = function startServer(options, cb) {
   app.get('/', updatePathOptions, render.renderMarkdownFileListing);
   app.get(/(\w+\.md)$/, updatePathOptions, render.renderMarkdownAsSlides);
   app.get('/assets/*', getAsset);
-  app.get('/*', staticDir(process.cwd()));
+  app.use(staticDir(process.cwd()));
 
   const server = app.listen(options.port);
 


### PR DESCRIPTION
Fix handling of static files by specifying base directory as root for all static requests.

This *does* fix #115 for me locally, but another pair of eyes would help here.