### PR TITLE
Add custom template options

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,13 +285,13 @@ reveal-md slides.md --port 8888
 
 ### Custom Template
 
-Override reveal.js HTML template (default: [this one](https://github.com/webpro/reveal-md/blob/master/lib/template/reveal.html))
+Override reveal.js HTML template ([default template](https://github.com/webpro/reveal-md/blob/master/lib/template/reveal.html)):
 
 ``` bash
 reveal-md slides.md --reveal-template my-reveal-template.html
 ```
 
-Override listing HTML template (default: [this one](https://github.com/webpro/reveal-md/blob/master/lib/template/reveal.html))
+Override listing HTML template ([default template](https://github.com/webpro/reveal-md/blob/master/lib/template/reveal.html)):
 
 ``` bash
 reveal-md slides.md --listing-template my-listing-template.html

--- a/README.md
+++ b/README.md
@@ -283,6 +283,20 @@ Override port (default: `1948`):
 reveal-md slides.md --port 8888
 ```
 
+### Custom Template
+
+Override reveal.js HTML template (default: [this one](https://github.com/webpro/reveal-md/blob/master/lib/template/reveal.html))
+
+``` bash
+reveal-md slides.md --reveal-template my-reveal-template.html
+```
+
+Override listing HTML template (default: [this one](https://github.com/webpro/reveal-md/blob/master/lib/template/reveal.html))
+
+``` bash
+reveal-md slides.md --listing-template my-listing-template.html
+```
+
 ## Related Projects & Alternatives
 
 * [Slides](https://slides.com/) is a place for creating, presenting and sharing slide decks.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -44,6 +44,8 @@ program
   .option('-S, --static [dir]', 'Export static html to directory [_static]. Incompatible with --print.', defaults.static)
   .option('-v, --vertical-separator <separator>', 'Vertical slide separator', defaults.verticalSeparator)
   .option('-w, --watch', `Watch for changes in markdown file and livereload presentation [${libDefaults.watch}]`, defaults.watch)
+  .option('-r, --reveal-template [filename]', 'Template file for reveal.js', defaults.revealTemplate)
+  .option('-l, --listing-template [filename]', 'Template file for listing', defaults.listingTemplate)
   .parse(process.argv);
 
 if(program.args.length > 2) {

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -8,6 +8,8 @@
   "port": 1948,
   "print": false,
   "revealOptions": {},
+  "revealTemplate": "",
+  "listingTemplate": "",
   "theme": "black",
   "title": "reveal-md",
   "separator": "^(\r\n?|\n)---(\r\n?|\n)$",

--- a/lib/options.js
+++ b/lib/options.js
@@ -9,8 +9,6 @@ const revealBasePath = path.resolve(require.resolve('reveal.js'), '..', '..');
 const highlightThemePath = path.resolve(require.resolve('highlight.js'), '..', '..', 'styles');
 const templatePath = path.join(__dirname, 'template', 'reveal.html');
 const templateListingPath = path.join(__dirname, 'template', 'listing.html');
-const template = fs.readFileSync(templatePath).toString();
-const templateListing = fs.readFileSync(templateListingPath).toString();
 
 const revealThemes = glob.sync('css/theme/*.css', {cwd: revealBasePath});
 const localThemes = glob.sync('theme/*.css', {cwd: process.cwd()});
@@ -84,6 +82,8 @@ const optionList = [
   'print',
   'preprocessor',
   'revealOptions',
+  'revealTemplate',
+  'listingTemplate',
   'scripts',
   'css',
   'separator',
@@ -115,8 +115,8 @@ function parseOptions(args) {
   options.highlightThemePath = highlightThemePath;
 
   options.base = () => options.static ? '.' : '';
-  options.template = () => template;
-  options.templateListing = () => templateListing;
+  options.template = () => fs.readFileSync(options.revealTemplate || templatePath).toString();
+  options.templateListing = () => fs.readFileSync(options.listingTemplate || templateListingPath).toString();
   options.themeUrl = () => getThemeUrl(options);
   options.highlightThemeUrl = () => `${options.base()}/css/highlight/${options.highlightTheme}.css`;
   options.revealOptionsStr = () => JSON.stringify(options.revealOptions || defaults.revealOptions);


### PR DESCRIPTION
Hi !

These changes allow the use of custom HTML templates. These can replace the templates found in the `lib/template` directory.

The `-r` `--reveal-template` option will override the `lib/template/reveal.html` file.

The `-l` `--listing-template` option will override the `lib/template/listing.html` file.

---

Modified files include :
* `README.md` : Add a `Custom Template` section
* `bin/cli.js` : Add CLI options
* `lib/defaults.json` : Add (empty) defaults for template file paths
* `lib/options.js` : Use templates from options if provided