### PR TITLE
Fix listing template URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Override reveal.js HTML template ([default template](https://github.com/webpro/r
 reveal-md slides.md --reveal-template my-reveal-template.html
 ```
 
-Override listing HTML template ([default template](https://github.com/webpro/reveal-md/blob/master/lib/template/reveal.html)):
+Override listing HTML template ([default template](https://github.com/webpro/reveal-md/blob/master/lib/template/listing.html)):
 
 ``` bash
 reveal-md slides.md --listing-template my-listing-template.html


### PR DESCRIPTION
README is pointing to the wrong link to default listing template. This is a fix for that for better clarity.