### PR TITLE
Make ?print-pdf actually work.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -122,8 +122,6 @@ function parseOptions(args) {
   options.highlightThemeUrl = () => `${options.base()}/css/highlight/${options.highlightTheme}.css`;
   options.revealOptionsStr = () => JSON.stringify(options.revealOptions || defaults.revealOptions);
 
-  options.print = _.get(options, 'query.print-pdf', options.print);
-
   return options;
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -37,6 +37,7 @@ function render(markdown, options) {
     slides: slides.slides,
     scripts: slides.view.scripts
   });
+  view.print = view.print || (options.query['print-pdf'] !== undefined);
 
   debug(`Rendering ${options.relativePath} with %O from %O`, view, markdown);
 


### PR DESCRIPTION
Current code in options.js doesn't work because the `query.print-pdf` property
will have an empty string as its value when the URL is like `?print-pdf`,
evaluating to false.

Even when it evaluates to true, it'll be a problem because then reveal-md
handles it like the `--print` command-line flag has been passed and tries to
invoke phantomjs.

Instead, sets `view.print` right before passing it to mustache.