### PR TITLE
Allow absolute path for preprocessor

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -74,7 +74,10 @@ function parseAssetsPath(assets) {
 }
 
 function parsePreprocessorArg(preprocessor) {
-  return preprocessor ? require(path.join(process.cwd(), preprocessor)) : _.identity;
+  if(preprocessor && preprocessor[0] != '/') {
+    preprocessor = path.join(process.cwd(), preprocessor);
+  }
+  return preprocessor ? require(preprocessor) : _.identity;
 }
 
 const optionList = [


### PR DESCRIPTION
A small patch that allows an absolute path to be used for the preprocessor path.
