### PR TITLE
Make preprocessor function asynchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,14 @@ the script `preproc.js`:
 ```javascript
 // headings trigger a new slide
 // headings with a caret (e.g., '##^ foo`) trigger a new vertical slide
-module.exports = (markdown, options, callback) => {
-  return callback(null, markdown.split('\n').map((line, index) => {
-    if(!/^#/.test(line) || index === 0) return line;
-    const is_vertical = /#\^/.test(line);
-    return (is_vertical ? '\n----\n\n' : '\n---\n\n') + line.replace('#^', '#');
-  }).join('\n'));
+module.exports = (markdown, options) => {
+  return new Promise((resolve, reject) => {
+    return resolve(markdown.split('\n').map((line, index) => {
+      if(!/^#/.test(line) || index === 0) return line;
+      const is_vertical = /#\^/.test(line);
+      return (is_vertical ? '\n----\n\n' : '\n---\n\n') + line.replace('#^', '#');
+    }).join('\n'));
+  });
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -220,12 +220,12 @@ the script `preproc.js`:
 ```javascript
 // headings trigger a new slide
 // headings with a caret (e.g., '##^ foo`) trigger a new vertical slide
-module.exports = (markdown, options) => {
-  return markdown.split('\n').map((line, index) => {
+module.exports = (markdown, options, callback) => {
+  return callback(null, markdown.split('\n').map((line, index) => {
     if(!/^#/.test(line) || index === 0) return line;
     const is_vertical = /#\^/.test(line);
     return (is_vertical ? '\n----\n\n' : '\n---\n\n') + line.replace('#^', '#');
-  }).join('\n');
+  }).join('\n'));
 };
 ```
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -74,7 +74,11 @@ function parseAssetsPath(assets) {
 }
 
 function parsePreprocessorArg(preprocessor) {
-  return preprocessor ? require(path.join(process.cwd(), preprocessor)) : (m,o,c)=>{c(null,m);};
+  return preprocessor
+    ? require(path.join(process.cwd(), preprocessor))
+    : (m, o, c) => {
+        c(null, m);
+      };
 }
 
 const optionList = [

--- a/lib/options.js
+++ b/lib/options.js
@@ -74,7 +74,7 @@ function parseAssetsPath(assets) {
 }
 
 function parsePreprocessorArg(preprocessor) {
-  return preprocessor ? require(path.join(process.cwd(), preprocessor)) : _.identity;
+  return preprocessor ? require(path.join(process.cwd(), preprocessor)) : (m,o,c)=>{c(null,m);};
 }
 
 const optionList = [

--- a/lib/options.js
+++ b/lib/options.js
@@ -74,13 +74,13 @@ function parseAssetsPath(assets) {
 }
 
 function parsePreprocessorArg(preprocessor) {
-  if(!_.startsWith(preprocessor, '/')) {
+  if(preprocessor && !_.startsWith(preprocessor, '/')) {
     preprocessor = path.join(process.cwd(), preprocessor);
   }
   return preprocessor
     ? require(preprocessor)
-    : (m,o,c) => {
-      c(null, m);
+    : (m,o) => {
+      return new Promise((resolve,reject) => {return resolve(m);});
     };
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -24,24 +24,29 @@ function parseSlides(markdown, options) {
   const yaml = parseYamlFrontMatter(markdown);
   const view = parseOptions(_.merge({}, yaml.options, options));
   const slidifyOptions = getSlidifyOptions(view);
-  const processedMarkdown = view.preprocessorFn(yaml.markdown, view);
-  return {
-    view,
-    slides: md.slidify(processedMarkdown, slidifyOptions)
-  };
+  return new Promise((resolve,reject) => {
+    view.preprocessorFn(yaml.markdown, view, (err, processedMarkdown) => {
+        if(err) return reject(err);
+        resolve({
+          view,
+          slides: md.slidify(processedMarkdown, slidifyOptions)
+        });
+    });
+  });
 }
 
 function render(markdown, options) {
-  const slides = parseSlides(markdown, options);
-  const view = _.extend(slides.view, {
-    slides: slides.slides,
-    scripts: slides.view.scripts
+  return parseSlides(markdown, options).then((slides)=>{
+    const view = _.extend(slides.view, {
+        slides: slides.slides,
+        scripts: slides.view.scripts
+    });
+    view.print = view.print || _.get(options, 'query.print-pdf') !== undefined;
+
+    debug(`Rendering ${options.relativePath} with %O from %O`, view, markdown);
+
+    return Mustache.to_html(view.templateSlides(), view);
   });
-  view.print = view.print || _.get(options, 'query.print-pdf') !== undefined;
-
-  debug(`Rendering ${options.relativePath} with %O from %O`, view, markdown);
-
-  return Mustache.to_html(view.templateSlides(), view);
 }
 
 function renderMarkdownAsSlides(req, res) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -24,22 +24,22 @@ function parseSlides(markdown, options) {
   const yaml = parseYamlFrontMatter(markdown);
   const view = parseOptions(_.merge({}, yaml.options, options));
   const slidifyOptions = getSlidifyOptions(view);
-  return new Promise((resolve,reject) => {
+  return new Promise((resolve, reject) => {
     view.preprocessorFn(yaml.markdown, view, (err, processedMarkdown) => {
-        if(err) return reject(err);
-        resolve({
-          view,
-          slides: md.slidify(processedMarkdown, slidifyOptions)
-        });
+      if (err) return reject(err);
+      resolve({
+        view,
+        slides: md.slidify(processedMarkdown, slidifyOptions)
+      });
     });
   });
 }
 
 function render(markdown, options) {
-  return parseSlides(markdown, options).then((slides)=>{
+  return parseSlides(markdown, options).then(slides => {
     const view = _.extend(slides.view, {
-        slides: slides.slides,
-        scripts: slides.view.scripts
+      slides: slides.slides,
+      scripts: slides.view.scripts
     });
     view.print = view.print || _.get(options, 'query.print-pdf') !== undefined;
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -24,14 +24,11 @@ function parseSlides(markdown, options) {
   const yaml = parseYamlFrontMatter(markdown);
   const view = parseOptions(_.merge({}, yaml.options, options));
   const slidifyOptions = getSlidifyOptions(view);
-  return new Promise((resolve, reject) => {
-    view.preprocessorFn(yaml.markdown, view, (err, processedMarkdown) => {
-      if (err) return reject(err);
-      resolve({
-        view,
-        slides: md.slidify(processedMarkdown, slidifyOptions)
-      });
-    });
+  return view.preprocessorFn(yaml.markdown, view).then(function(processedMarkdown) {
+    return {
+      view,
+      slides: md.slidify(processedMarkdown, slidifyOptions)
+    };
   });
 }
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -38,9 +38,7 @@ module.exports = function renderStaticMarkup(options) {
   );
 
   const staticDirs = typeof options.staticDirs === 'string' ? options.staticDirs.split(',') : options.staticDirs;
-  const extraDirs = staticDirs.map(dir =>
-    fs.copyAsync(path.join(process.cwd(), dir), path.join(targetPath, dir))
-  );
+  const extraDirs = staticDirs.map(dir => fs.copyAsync(path.join(process.cwd(), dir), path.join(targetPath, dir)));
   awaits.push.apply(awaits, extraDirs);
 
   const parseSlideAwait = fs

--- a/test/preproc.js
+++ b/test/preproc.js
@@ -1,7 +1,9 @@
-module.exports = (markdown, options, callback) => {
-  return callback(null, markdown.split('\n').map((line, index) => {
-    if(!/^#/.test(line) || index === 0) return line;
-    const is_vertical = /#\^/.test(line);
-    return (is_vertical ? '\n----\n\n' : '\n---\n\n') + line.replace('#^', '#');
-  }).join('\n'));
+module.exports = (markdown, options) => {
+  return new Promise((resolve, reject) => {
+    return resolve(markdown.split('\n').map((line, index) => {
+        if(!/^#/.test(line) || index === 0) return line;
+        const is_vertical = /#\^/.test(line);
+        return (is_vertical ? '\n----\n\n' : '\n---\n\n') + line.replace('#^', '#');
+    }).join('\n'));
+  });
 };

--- a/test/preproc.js
+++ b/test/preproc.js
@@ -1,7 +1,7 @@
-module.exports = (markdown, options) => {
-  return markdown.split('\n').map((line, index) => {
+module.exports = (markdown, options, callback) => {
+  return callback(null, markdown.split('\n').map((line, index) => {
     if(!/^#/.test(line) || index === 0) return line;
     const is_vertical = /#\^/.test(line);
     return (is_vertical ? '\n----\n\n' : '\n---\n\n') + line.replace('#^', '#');
-  }).join('\n');
+  }).join('\n'));
 };

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -6,117 +6,147 @@ const markdown = fs.readFileSync('demo/a.md').toString();
 
 describe('render', () => {
 
-  it('should render basic template', () => {
-    const actual = render.render('', {});
-    expect(actual).toContain('<title>reveal-md</title>');
-    expect(actual).toContain('<link rel="stylesheet" href="/css/theme/black.css"');
-    expect(actual).toContain('<link rel="stylesheet" href="/css/highlight/zenburn.css"');
-    expect(actual).toContain('<link rel="stylesheet" href="/css/print/paper.css" type="text/css" media="print">');
-    expect(actual).toContain('<div class="slides"><section  data-markdown><script type="text/template"></script></section></div>');
-    expect(actual).toContain('<script src="/js/reveal.js"></script>');
-    expect(actual).toContain('{ src: \'/plugin/markdown/markdown.js\'');
-    expect(actual).toContain('var options = {};');
+  it('should render basic template', (done) => {
+    render.render('', {}).then((actual) => {
+        expect(actual).toContain('<title>reveal-md</title>');
+        expect(actual).toContain('<link rel="stylesheet" href="/css/theme/black.css"');
+        expect(actual).toContain('<link rel="stylesheet" href="/css/highlight/zenburn.css"');
+        expect(actual).toContain('<link rel="stylesheet" href="/css/print/paper.css" type="text/css" media="print">');
+        expect(actual).toContain('<div class="slides"><section  data-markdown><script type="text/template"></script></section></div>');
+        expect(actual).toContain('<script src="/js/reveal.js"></script>');
+        expect(actual).toContain('{ src: \'/plugin/markdown/markdown.js\'');
+        expect(actual).toContain('var options = {};');
+        done();
+    });
   });
 
-  it('should render markdown content', () => {
-    const actual = render.render('# header', {});
-    expect(actual).toContain('<div class="slides"><section  data-markdown><script type="text/template"># header</script></section></div>');
+  it('should render markdown content', (done) => {
+    render.render('# header', {}).then((actual) => {
+        expect(actual).toContain('<div class="slides"><section  data-markdown><script type="text/template"># header</script></section></div>');
+        done();
+    });
   });
 
-  it('should render custom scripts', () => {
-    const actual = render.render('# header', {scripts: 'custom.js,also.js'});
-    expect(actual).toContain('<script src="/_assets/custom.js"></script>');
-    expect(actual).toContain('<script src="/_assets/also.js"></script>');
+  it('should render custom scripts', (done) => {
+    render.render('# header', {scripts: 'custom.js,also.js'}).then((actual)=>{
+        expect(actual).toContain('<script src="/_assets/custom.js"></script>');
+        expect(actual).toContain('<script src="/_assets/also.js"></script>');
+        done();
+    });
   });
 
-  it('should render custom css after theme', () => {
-    const actual = render.render('# header', {css: 'style1.css,style2.css'});
-    const themeLink = '<link rel="stylesheet" href="/css/highlight/zenburn.css">';
-    const style1Link = '<link rel="stylesheet" href="/_assets/style1.css">';
-    const style2Link = '<link rel="stylesheet" href="/_assets/style2.css">';
-    expect(actual).toContain(themeLink);
-    expect(actual).toContain(style1Link);
-    expect(actual).toContain(style2Link);
-    expect(actual.indexOf(style1Link)).toBeGreaterThan(actual.indexOf(themeLink));
-    expect(actual.indexOf(style2Link)).toBeGreaterThan(actual.indexOf(style1Link));
+  it('should render custom css after theme', (done) => {
+    render.render('# header', {css: 'style1.css,style2.css'}).then((actual)=>{
+        const themeLink = '<link rel="stylesheet" href="/css/highlight/zenburn.css">';
+        const style1Link = '<link rel="stylesheet" href="/_assets/style1.css">';
+        const style2Link = '<link rel="stylesheet" href="/_assets/style2.css">';
+        expect(actual).toContain(themeLink);
+        expect(actual).toContain(style1Link);
+        expect(actual).toContain(style2Link);
+        expect(actual.indexOf(style1Link)).toBeGreaterThan(actual.indexOf(themeLink));
+        expect(actual.indexOf(style2Link)).toBeGreaterThan(actual.indexOf(style1Link));
+        done();
+    });
   });
 
-  it('should render print stylesheet', () => {
-    const actual = render.render('', {print: true});
-    expect(actual).toContain('<link rel="stylesheet" href="/css/print/pdf.css" type="text/css" media="print">');
+  it('should render print stylesheet', (done) => {
+    render.render('', {print: true}).then((actual)=>{
+        expect(actual).toContain('<link rel="stylesheet" href="/css/print/pdf.css" type="text/css" media="print">');
+        done();
+    });
   });
 
-  it('should render alternate theme stylesheet', () => {
-    const actual = render.render('', {theme: 'white'});
-    expect(actual).toContain('<link rel="stylesheet" href="/css/theme/white.css"');
+  it('should render alternate theme stylesheet', (done) => {
+    render.render('', {theme: 'white'}).then((actual)=>{
+        expect(actual).toContain('<link rel="stylesheet" href="/css/theme/white.css"');
+        done();
+    });
   });
 
-  it('should render root-based domain-less links for static markup', () => {
-    const actual = render.render('', {static: true});
-    expect(actual.match(/href="\.\//g).length).toBe(4);
-    expect(actual.match(/src="\.\//g).length).toBe(2);
-    expect(actual.match(/src:\ '\.\//g).length).toBe(7);
+  it('should render root-based domain-less links for static markup', (done) => {
+    render.render('', {static: true}).then((actual)=>{
+        expect(actual.match(/href="\.\//g).length).toBe(4);
+        expect(actual.match(/src="\.\//g).length).toBe(2);
+        expect(actual.match(/src:\ '\.\//g).length).toBe(7);
+        done();
+    });
   });
 
-  it('should render reveal.js options', () => {
-    const actual = render.render('', {revealOptions: {controls: false}});
-    expect(actual).toContain('var options = {"controls":false};');
+  it('should render reveal.js options', (done) => {
+    render.render('', {revealOptions: {controls: false}}).then((actual)=>{
+        expect(actual).toContain('var options = {"controls":false};');
+        done();
+    });
   });
-});
-
-describe('parseSlides', () => {
-
-  it('should render slides split by horizontal separator', () => {
-    const actual = render.parseSlides('Slide A\n\n---\n\nSlide B', {});
-    expect(actual.slides).toEqual('' +
-      '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
-      '<section  data-markdown><script type="text/template">\nSlide B</script></section>');
   });
 
-  it('should render sub slides split by vertical separator', () => {
-    const actual = render.parseSlides('Slide A\n\n---\n\nSlide B\n\n----\n\nSlide C', {});
-    expect(actual.slides).toEqual('' +
-      '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
-      '<section >' +
-        '<section data-markdown><script type="text/template">\nSlide B\n</script></section>' +
-        '<section data-markdown><script type="text/template">\nSlide C</script></section>' +
-      '</section>');
+describe('parseSlides', (done) => {
+
+  it('should render slides split by horizontal separator', (done) => {
+    render.parseSlides('Slide A\n\n---\n\nSlide B', {}).then((actual)=>{
+        expect(actual.slides).toEqual('' +
+                '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
+                '<section  data-markdown><script type="text/template">\nSlide B</script></section>');
+        done();
+    });
   });
 
-  it('should render slides split by custom separators', () => {
-    const actual = render.parseSlides('Slide A\n\n\nSlide B\n\nSlide C', {separator: '\n\n\n', verticalSeparator: '\n\n'});
-    expect(actual.slides).toEqual('' +
-      '<section  data-markdown><script type="text/template">Slide A</script></section>' +
-      '<section >' +
-        '<section data-markdown><script type="text/template">Slide B</script></section>' +
-        '<section data-markdown><script type="text/template">Slide C</script></section>' +
-      '</section>');
+  it('should render sub slides split by vertical separator', (done) => {
+    render.parseSlides('Slide A\n\n---\n\nSlide B\n\n----\n\nSlide C', {}).then((actual)=>{
+        expect(actual.slides).toEqual('' +
+                '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
+                '<section >' +
+                '<section data-markdown><script type="text/template">\nSlide B\n</script></section>' +
+                '<section data-markdown><script type="text/template">\nSlide C</script></section>' +
+                '</section>');
+        done();
+    });
   });
 
-  it('should render speaker notes', () => {
-    const actual = render.parseSlides('Slide A\n\nNote: test', {});
-    expect(actual.slides).toEqual('<section  data-markdown><script type="text/template">Slide A\n\n<aside class="notes"><p>test</p>\n</aside></script></section>');
+  it('should render slides split by custom separators', (done) => {
+    render.parseSlides('Slide A\n\n\nSlide B\n\nSlide C', {separator: '\n\n\n', verticalSeparator: '\n\n'}).then((actual)=>{
+        expect(actual.slides).toEqual('' +
+                '<section  data-markdown><script type="text/template">Slide A</script></section>' +
+                '<section >' +
+                '<section data-markdown><script type="text/template">Slide B</script></section>' +
+                '<section data-markdown><script type="text/template">Slide C</script></section>' +
+                '</section>');
+        done();
+    });
   });
 
-  it('should parse YAML front matter', () => {
-    const actual = render.parseSlides('---\nseparator: <!--s-->\n---\nSlide A<!--s-->Slide B', {});
-    expect(actual.slides).toEqual('' +
-      '<section  data-markdown><script type="text/template">\nSlide A</script></section>' +
-      '<section  data-markdown><script type="text/template">Slide B</script></section>');
+  it('should render speaker notes', (done) => {
+    render.parseSlides('Slide A\n\nNote: test', {}).then((actual)=>{
+        expect(actual.slides).toEqual('<section  data-markdown><script type="text/template">Slide A\n\n<aside class="notes"><p>test</p>\n</aside></script></section>');
+        done();
+    });
   });
 
-  it('should ignore comments (e.g. custom slide attributes)', () => {
-    const actual = render.parseSlides('Slide A\n\n---\n\n<!-- .slide: data-background="./image1.png" -->\nSlide B', {});
-    expect(actual.slides).toEqual('' +
-      '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
-      '<section  data-markdown><script type="text/template">\n<!-- .slide: data-background="./image1.png" -->\nSlide B</script></section>');
+  it('should parse YAML front matter', (done) => {
+    render.parseSlides('---\nseparator: <!--s-->\n---\nSlide A<!--s-->Slide B', {}).then((actual)=>{
+        expect(actual.slides).toEqual('' +
+                '<section  data-markdown><script type="text/template">\nSlide A</script></section>' +
+                '<section  data-markdown><script type="text/template">Slide B</script></section>');
+        done();
+    });
   });
 
-  it('should use preprocesser for markdown', () => {
-    const actual = render.parseSlides('# Slide A\n\ncontent\n\n# Slide B\n\ncontent', {preprocessor: 'test/preproc'});
-    expect(actual.slides).toEqual('' +
-      '<section  data-markdown><script type="text/template"># Slide A\n\ncontent\n\n</script></section>' +
-      '<section  data-markdown><script type="text/template">\n# Slide B\n\ncontent</script></section>');
+  it('should ignore comments (e.g. custom slide attributes)', (done) => {
+    render.parseSlides('Slide A\n\n---\n\n<!-- .slide: data-background="./image1.png" -->\nSlide B', {}).then((actual)=>{
+        expect(actual.slides).toEqual('' +
+                '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
+                '<section  data-markdown><script type="text/template">\n<!-- .slide: data-background="./image1.png" -->\nSlide B</script></section>');
+        done();
+    });
+  });
+
+  it('should use preprocesser for markdown', (done) => {
+    render.parseSlides('# Slide A\n\ncontent\n\n# Slide B\n\ncontent', {preprocessor: 'test/preproc'}).then((actual)=>{
+        expect(actual.slides).toEqual('' +
+                '<section  data-markdown><script type="text/template"># Slide A\n\ncontent\n\n</script></section>' +
+                '<section  data-markdown><script type="text/template">\n# Slide B\n\ncontent</script></section>');
+        done();
+    });
   });
 
 });


### PR DESCRIPTION
This is a little hacky, but illustrates the idea.

render() already returns a promise, but doesn't call the preprocessor asynchronously.
This alters that behaviour so that projects such as https://github.com/commenthol/markedpp can be used as a preprocessor directly.

Without this it is very difficult to write a preprocessor function that will allow the use of asynchronous preprocessors.