### PR TITLE
Address livereload warning prior to breaking change

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -37,7 +37,11 @@ module.exports = function startServer(options, cb) {
 
   if (options.watch) {
     const liveReloadServer = liveReload.createServer({
-      exts: ['md']
+      /* Live Reload defaults + 'md' */
+      exts: [
+          'html', 'css', 'js', 'png', 'gif', 'jpg',
+          'php', 'php5', 'py', 'rb', 'erb', 'coffee',
+          'md']
     });
     liveReloadServer.watch(process.cwd());
   }


### PR DESCRIPTION
Addresses the warning in #151 - and ensures that the release of livereload 0.6.4 will not change behaviour.