### PR TITLE
Permit notesSeparator in YAML header to be passed to markdown processor

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -95,7 +95,8 @@ const optionList = [
   'theme',
   'title',
   'verticalSeparator',
-  'watch'
+  'watch',
+  'notesSeparator'
 ];
 
 function parseOptions(args) {


### PR DESCRIPTION
Quick fix for #160 