### PR TITLE
Make preprocessor optional again

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -74,7 +74,7 @@ function parseAssetsPath(assets) {
 }
 
 function parsePreprocessorArg(preprocessor) {
-  if(!_.startsWith(preprocessor, '/')) {
+  if(preprocessor && !_.startsWith(preprocessor, '/')) {
     preprocessor = path.join(process.cwd(), preprocessor);
   }
   return preprocessor ? require(preprocessor) : _.identity;


### PR DESCRIPTION
Hi there, I love this tool and have used it for years.

Today, I tried using the latest version and found it is not working when no `preprocessor` option is specified. It assumes a string value for `preprocessor`, but its default value is `false`. The tests are failing because of this as well.

This PR simply re-adds the check for `preprocessor` that was removed in https://github.com/webpro/reveal-md/commit/cfe3a7ac76ca4fac150356be64507bf839f8d57e.

Thank you!