### PR TITLE
YAML Frontend data made available to mustache

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -36,9 +36,11 @@ function parseSlides(markdown, options) {
 
 function render(markdown, options) {
   return parseSlides(markdown, options).then(slides => {
+    const yaml = parseYamlFrontMatter(markdown);
     const view = _.extend(slides.view, {
       slides: slides.slides,
-      scripts: slides.view.scripts
+      scripts: slides.view.scripts,
+      yaml: yaml.options
     });
     view.print = view.print || _.get(options, 'query.print-pdf') !== undefined;
 

--- a/package.json
+++ b/package.json
@@ -29,25 +29,25 @@
   },
   "dependencies": {
     "bluebird": "3.5.1",
-    "commander": "2.13.0",
+    "commander": "2.15.0",
     "express": "4.16.2",
-    "fs-extra": "3.0.1",
+    "fs-extra": "5.0.0",
     "glob": "7.1.2",
-    "got": "8.0.3",
+    "got": "8.2.0",
     "highlight.js": "9.12.0",
     "image-data-uri": "1.0.1",
-    "livereload": "0.6.3",
-    "lodash": "4.17.4",
+    "livereload": "0.7.0",
+    "lodash": "4.17.5",
     "mustache": "2.3.0",
     "open": "0.0.5",
     "reveal.js": "3.6.0",
-    "yaml-front-matter": "3.4.0"
+    "yaml-front-matter": "3.4.1"
   },
   "devDependencies": {
     "debug": "3.1.0",
-    "expect": "22.1.0",
-    "mocha": "5.0.0",
-    "prettier": "1.10.2"
+    "expect": "22.4.0",
+    "mocha": "5.0.4",
+    "prettier": "1.11.1"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
For templating it would be useful to include YAML frontend data to Mustache templating, this way it is possible to templatize a cover slide with the front matter content (e.g., with title, subtitle, authors, etc.).