### PR TITLE
Insert OpenGraph metadata to static builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,14 @@ Use `--static-dirs` to copy directories with static assets to the target directo
 reveal-md slides.md --static --static-dirs=assets
 ```
 
+Additional `--absolute-url` and `--featured-slide` parameters could be used to
+generate [OpenGraph](http://ogp.me) metadata enabling more attractive rendering
+for slide deck links when shared in some social sites.
+
+```bash
+reveal-md slides.md --static _site --absolute-url https://example.com --featured-slide 5
+```
+
 ### Disable Auto-open Browser
 
 Disable to automatically open your web browser:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,7 +13,10 @@ program
   .description('See https://github.com/webpro/reveal-md for more details.')
   .option('    --title <title>', 'Title of the presentation')
   .option(`-s, --separator <separator>`, `Slide separator [default: 3 dashes (---) surrounded by two blank lines]`)
-  .option('-S, --vertical-separator <separator>', 'Vertical slide separator [default: 4 dashes (----) surrounded by two blank lines]')
+  .option(
+    '-S, --vertical-separator <separator>',
+    'Vertical slide separator [default: 4 dashes (----) surrounded by two blank lines]'
+  )
   .option('-t, --theme <theme>', `Theme [default: ${defaults.theme}]`)
   .option('    --highlight-theme <theme>', `Highlight theme [default: ${defaults.highlightTheme}]`)
   .option('    --css <files>', 'CSS files to inject into the page')
@@ -23,14 +26,21 @@ program
   .option('    --listing-template <filename>', 'Template file for listing')
   .option('    --print [filename]', 'Print to PDF file')
   .option('    --static [dir]', 'Export static html to directory [_static]. Incompatible with --print.')
-  .option('    --static-dirs <dirs>', 'Extra directories to copy into static directory. Only used in conjunction with --static.')
+  .option(
+    '    --static-dirs <dirs>',
+    'Extra directories to copy into static directory. Only used in conjunction with --static.'
+  )
   .option('-w, --watch', `Watch for changes in markdown file and livereload presentation`)
   .option('    --disable-auto-open', 'Disable auto-opening your web browser')
   .option('    --host <host>', `Host [default: ${defaults.host}]`)
   .option('    --port <port>', `Port [default: ${defaults.port}]`)
+  .option(
+    '    --featured-slide <num>',
+    'Capture snapshot from this slide to be used as og:image for static build. Defaults to first slide. Only used with --static.'
+  )
   .parse(process.argv);
 
-if(program.args.length > 2) {
+if (program.args.length > 2) {
   program.help();
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,6 +38,10 @@ program
     '    --featured-slide <num>',
     'Capture snapshot from this slide to be used as og:image for static build. Defaults to first slide. Only used with --static.'
   )
+  .option(
+    '    --absolute-url <url>',
+    'Define url used for hosting static build. This is included in OpenGraph metadata. Only used with --static.'
+  )
   .parse(process.argv);
 
 if (program.args.length > 2) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,6 +42,7 @@ program
     '    --absolute-url <url>',
     'Define url used for hosting static build. This is included in OpenGraph metadata. Only used with --static.'
   )
+  .option('    --puppeteer-launch-args <args>', 'Customize how Puppeteer launches Chromium. Needed for some CI setups.')
   .parse(process.argv);
 
 if (program.args.length > 2) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -36,7 +36,7 @@ program
   .option('    --port <port>', `Port [default: ${defaults.port}]`)
   .option(
     '    --featured-slide <num>',
-    'Capture snapshot from this slide to be used as og:image for static build. Defaults to first slide. Only used with --static.'
+    'Capture snapshot from this slide (numbering starts from 1) and use it as og:image for static build. Defaults to first slide. Only used with --static.'
   )
   .option(
     '    --absolute-url <url>',

--- a/lib/featured-slide.js
+++ b/lib/featured-slide.js
@@ -34,7 +34,7 @@ module.exports = function snapshot(options) {
   return new Promise((resolve, reject) => {
     startServer(opts, server => {
       const { initialPath, featuredSlide } = options;
-      const slideAnchor = featuredSlide ? `#/${featuredSlide}` : '';
+      const slideAnchor = isNaN(parseInt(featuredSlide, 10)) ? '' : `#/${parseInt(featuredSlide, 10) - 1}`;
       const url = `http://${options.host}:${options.port}/${initialPath}${slideAnchor}`;
 
       return puppeteer

--- a/lib/featured-slide.js
+++ b/lib/featured-slide.js
@@ -31,37 +31,42 @@ module.exports = function snapshot(options) {
 
   const snapshotFilename = path.basename(initialPath).replace(/[^/]+\.md$/, `${options.static}/featured-slide.jpg`);
 
-  startServer(opts, server => {
-    const { initialPath, featuredSlide } = options;
-    const slideAnchor = featuredSlide ? `#/${featuredSlide}` : '';
-    const url = `http://${options.host}:${options.port}/${initialPath}${slideAnchor}`;
+  return new Promise((resolve, reject) => {
+    startServer(opts, server => {
+      const { initialPath, featuredSlide } = options;
+      const slideAnchor = featuredSlide ? `#/${featuredSlide}` : '';
+      const url = `http://${options.host}:${options.port}/${initialPath}${slideAnchor}`;
 
-    return puppeteer
-      .launch()
-      .then(browser =>
-        browser
-          .newPage()
-          .then(page => {
-            return page.setViewport({ width: 1200, height: 1200 }).then(() => page);
-          })
-          .then(page => {
-            return page.goto(`${url}`, { waitUntil: 'load' }).then(() => {
-              return page
-                .screenshot({
-                  path: snapshotFilename,
-                  quality: 70,
-                  fullPage: true
-                })
-                .then(() => browser.close())
-                .then(() => server.close());
-            });
-          })
-      )
-      .catch(err => {
-        debug(err);
-        console.error(
-          `[Error while generating featured slide snapshot for "${options.relativePath}"]\n${err.toString()}`
-        );
-      });
+      return puppeteer
+        .launch(options.puppeteerLaunchArgs ? { args: options.puppeteerLaunchArgs.split(' ') } : {})
+        .then(browser =>
+          browser
+            .newPage()
+            .then(page => {
+              return page.setViewport({ width: 1200, height: 1200 }).then(() => page);
+            })
+            .then(page => {
+              return page.goto(`${url}`, { waitUntil: 'load' }).then(() => {
+                return page
+                  .screenshot({
+                    path: snapshotFilename,
+                    quality: 70,
+                    fullPage: true
+                  })
+                  .then(() => browser.close())
+                  .then(() => server.close());
+              });
+            })
+        )
+        .then(() => resolve(snapshotFilename))
+        .catch(err => {
+          debug(err);
+          server.close();
+          console.error(
+            `[Error while generating featured slide snapshot for "${options.relativePath}"]\n${err.toString()}`
+          );
+          reject(err);
+        });
+    });
   });
 };

--- a/lib/featured-slide.js
+++ b/lib/featured-slide.js
@@ -1,0 +1,67 @@
+//'use strict';
+/** Uses Puppeteer to capture screenshot from featured slide
+ *
+ * If featuredSlide is not configured in FrontMatter first slide in the set will
+ be used by default instead.
+ */
+
+const _ = require('lodash');
+const path = require('path');
+const debug = require('debug');
+const startServer = require('./serve');
+
+let puppeteer;
+
+try {
+  puppeteer = require('puppeteer');
+} catch (err) {}
+
+module.exports = function snapshot(options) {
+  const { initialPath } = options;
+
+  if (!puppeteer) {
+    console.warn(`Puppeteer unavailable, unable to create featured slide image for OpenGraph metadata.`);
+    return;
+  }
+
+  const opts = _.extend({}, options, {
+    print: false,
+    disableAutoOpen: true
+  });
+
+  const snapshotFilename = path.basename(initialPath).replace(/[^/]+\.md$/, `${options.static}/featured-slide.jpg`);
+
+  startServer(opts, server => {
+    const { initialPath, featuredSlide } = options;
+    const slideAnchor = featuredSlide ? `#/${featuredSlide}` : '';
+    const url = `http://${options.host}:${options.port}/${initialPath}${slideAnchor}`;
+
+    return puppeteer
+      .launch()
+      .then(browser =>
+        browser
+          .newPage()
+          .then(page => {
+            return page.setViewport({ width: 1200, height: 1200 }).then(() => page);
+          })
+          .then(page => {
+            return page.goto(`${url}`, { waitUntil: 'load' }).then(() => {
+              return page
+                .screenshot({
+                  path: snapshotFilename,
+                  quality: 70,
+                  fullPage: true
+                })
+                .then(() => browser.close())
+                .then(() => server.close());
+            });
+          })
+      )
+      .catch(err => {
+        debug(err);
+        console.error(
+          `[Error while generating featured slide snapshot for "${options.relativePath}"]\n${err.toString()}`
+        );
+      });
+  });
+};

--- a/lib/options.js
+++ b/lib/options.js
@@ -28,7 +28,8 @@ const optionList = [
   'notesSeparator',
   'noPhantom',
   'featuredSlide',
-  'absoluteUrl'
+  'absoluteUrl',
+  'puppeteerLaunchArgs'
 ];
 
 const getAssetPath = asset => `_assets/${asset}`;

--- a/lib/options.js
+++ b/lib/options.js
@@ -26,7 +26,8 @@ const optionList = [
   'verticalSeparator',
   'watch',
   'notesSeparator',
-  'noPhantom'
+  'noPhantom',
+  'featuredSlide'
 ];
 
 const getAssetPath = asset => `_assets/${asset}`;

--- a/lib/options.js
+++ b/lib/options.js
@@ -27,7 +27,8 @@ const optionList = [
   'watch',
   'notesSeparator',
   'noPhantom',
-  'featuredSlide'
+  'featuredSlide',
+  'absoluteUrl'
 ];
 
 const getAssetPath = asset => `_assets/${asset}`;

--- a/lib/static.js
+++ b/lib/static.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const url = require('url');
 const render = require('./render').render;
+const featuredSlide = require('./featured-slide');
 const parseYamlFrontMatter = require('./render').parseYamlFrontMatter;
 const imageDataURI = require('image-data-uri');
 const _ = require('lodash');
@@ -42,6 +43,8 @@ module.exports = function renderStaticMarkup(options) {
   const awaits = ['css', 'js', 'plugin', 'lib'].map(dir =>
     fs.copyAsync(path.join(options.revealBasePath, dir), path.join(targetPath, dir))
   );
+
+  awaits.push(featuredSlide(options));
 
   const staticDirs = typeof options.staticDirs === 'string' ? options.staticDirs.split(',') : options.staticDirs;
   const extraDirs = staticDirs.map(dir => fs.copyAsync(path.join(process.cwd(), dir), path.join(targetPath, dir)));

--- a/lib/template/reveal.html
+++ b/lib/template/reveal.html
@@ -5,6 +5,12 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
         <title>{{{title}}}</title>
+        {{#absoluteUrl}}
+          <meta property="og:title" content="{{{title}}}">
+          <meta property="og:type" content="website">
+          <meta property="og:image" content="{{{absoluteUrl}}}/featured-slide.jpg">
+          <meta property="og:url" content="{{{absoluteUrl}}}">
+        {{/absoluteUrl}}
         <link rel="stylesheet" href="{{{base}}}/css/reveal.css">
         <link rel="stylesheet" href="{{{themeUrl}}}" id="theme">
         <link rel="stylesheet" href="{{{base}}}{{{highlightThemeUrl}}}">
@@ -15,9 +21,13 @@
 
     {{#watch}}
 		<script>
-		  document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] +
-		  ':35729/livereload.js?snipver=1"></' + 'script>')
-		</script>
+		document.write(
+  '<script src="http://' +
+    (location.host || 'localhost').split(':')[0] +
+    ':35729/livereload.js?snipver=1"></' +
+    'script>'
+);
+</script>
     {{/watch}}
 
     </head>
@@ -77,7 +87,7 @@
         {{/scriptPaths}}
 
         <script>
-            Reveal.initialize(options);
-        </script>
+        Reveal.initialize(options);
+</script>
     </body>
 </html>

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -5,23 +5,26 @@ const render = require('../lib/render');
 const markdown = fs.readFileSync('demo/a.md').toString();
 
 describe('render', () => {
-
   it('should render basic template', () => {
     return render.render('', {}).then(actual => {
       expect(actual).toContain('<title>reveal-md</title>');
       expect(actual).toContain('<link rel="stylesheet" href="/css/theme/black.css"');
       expect(actual).toContain('<link rel="stylesheet" href="/css/highlight/zenburn.css"');
       expect(actual).toContain('<link rel="stylesheet" href="/css/print/paper.css" type="text/css" media="print">');
-      expect(actual).toContain('<div class="slides"><section  data-markdown><script type="text/template"></script></section></div>');
+      expect(actual).toContain(
+        '<div class="slides"><section  data-markdown><script type="text/template"></script></section></div>'
+      );
       expect(actual).toContain('<script src="/js/reveal.js"></script>');
-      expect(actual).toContain('{ src: \'/plugin/markdown/markdown.js\'');
+      expect(actual).toContain("{ src: '/plugin/markdown/markdown.js'");
       expect(actual).toContain('var options = {};');
     });
   });
 
   it('should render markdown content', () => {
     return render.render('# header', {}).then(actual => {
-      expect(actual).toContain('<div class="slides"><section  data-markdown><script type="text/template"># header</script></section></div>');
+      expect(actual).toContain(
+        '<div class="slides"><section  data-markdown><script type="text/template"># header</script></section></div>'
+      );
     });
   });
 
@@ -76,68 +79,93 @@ describe('render', () => {
       expect(actual).toMatch(/<title>Foo Bar<\/title>/);
     });
   });
+
+  it('should render OpenGraph metadata', () => {
+    return render.render('', { absoluteUrl: 'http://example.com', title: 'Foo Bar' }).then(actual => {
+      expect(actual).toContain('<meta property="og:title" content="Foo Bar">');
+      expect(actual).toContain('<meta property="og:image" content="http://example.com/featured-slide.jpg">');
+    });
+  });
 });
 
 describe('parseSlides', () => {
-
   it('should render slides split by horizontal separator', () => {
     render.parseSlides('Slide A\n\n---\n\nSlide B', {}).then(actual => {
-      expect(actual.slides).toEqual('' +
-        '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
-        '<section  data-markdown><script type="text/template">\nSlide B</script></section>');
+      expect(actual.slides).toEqual(
+        '' +
+          '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
+          '<section  data-markdown><script type="text/template">\nSlide B</script></section>'
+      );
     });
   });
 
   it('should render sub slides split by vertical separator', () => {
     render.parseSlides('Slide A\n\n---\n\nSlide B\n\n----\n\nSlide C', {}).then(actual => {
-      expect(actual.slides).toEqual('' +
-        '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
-        '<section >' +
-        '<section data-markdown><script type="text/template">\nSlide B\n</script></section>' +
-        '<section data-markdown><script type="text/template">\nSlide C</script></section>' +
-        '</section>');
+      expect(actual.slides).toEqual(
+        '' +
+          '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
+          '<section >' +
+          '<section data-markdown><script type="text/template">\nSlide B\n</script></section>' +
+          '<section data-markdown><script type="text/template">\nSlide C</script></section>' +
+          '</section>'
+      );
     });
   });
 
   it('should render slides split by custom separators', () => {
-    render.parseSlides('Slide A\n\n\nSlide B\n\nSlide C', { separator: '\n\n\n', verticalSeparator: '\n\n' }).then(actual => {
-      expect(actual.slides).toEqual('' +
-        '<section  data-markdown><script type="text/template">Slide A</script></section>' +
-        '<section >' +
-        '<section data-markdown><script type="text/template">Slide B</script></section>' +
-        '<section data-markdown><script type="text/template">Slide C</script></section>' +
-        '</section>');
-    });
+    render
+      .parseSlides('Slide A\n\n\nSlide B\n\nSlide C', { separator: '\n\n\n', verticalSeparator: '\n\n' })
+      .then(actual => {
+        expect(actual.slides).toEqual(
+          '' +
+            '<section  data-markdown><script type="text/template">Slide A</script></section>' +
+            '<section >' +
+            '<section data-markdown><script type="text/template">Slide B</script></section>' +
+            '<section data-markdown><script type="text/template">Slide C</script></section>' +
+            '</section>'
+        );
+      });
   });
 
   it('should render speaker notes', () => {
     render.parseSlides('Slide A\n\nNote: test', {}).then(actual => {
-      expect(actual.slides).toEqual('<section  data-markdown><script type="text/template">Slide A\n\n<aside class="notes"><p>test</p>\n</aside></script></section>');
+      expect(actual.slides).toEqual(
+        '<section  data-markdown><script type="text/template">Slide A\n\n<aside class="notes"><p>test</p>\n</aside></script></section>'
+      );
     });
   });
 
   it('should parse YAML front matter', () => {
     render.parseSlides('---\nseparator: <!--s-->\n---\nSlide A<!--s-->Slide B', {}).then(actual => {
-      expect(actual.slides).toEqual('' +
-        '<section  data-markdown><script type="text/template">\nSlide A</script></section>' +
-        '<section  data-markdown><script type="text/template">Slide B</script></section>');
+      expect(actual.slides).toEqual(
+        '' +
+          '<section  data-markdown><script type="text/template">\nSlide A</script></section>' +
+          '<section  data-markdown><script type="text/template">Slide B</script></section>'
+      );
     });
   });
 
   it('should ignore comments (e.g. custom slide attributes)', () => {
-    render.parseSlides('Slide A\n\n---\n\n<!-- .slide: data-background="./image1.png" -->\nSlide B', {}).then(actual => {
-      expect(actual.slides).toEqual('' +
-        '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
-        '<section  data-markdown><script type="text/template">\n<!-- .slide: data-background="./image1.png" -->\nSlide B</script></section>');
-    });
+    render
+      .parseSlides('Slide A\n\n---\n\n<!-- .slide: data-background="./image1.png" -->\nSlide B', {})
+      .then(actual => {
+        expect(actual.slides).toEqual(
+          '' +
+            '<section  data-markdown><script type="text/template">Slide A\n</script></section>' +
+            '<section  data-markdown><script type="text/template">\n<!-- .slide: data-background="./image1.png" -->\nSlide B</script></section>'
+        );
+      });
   });
 
   it('should use preprocesser for markdown', () => {
-    render.parseSlides('# Slide A\n\ncontent\n\n# Slide B\n\ncontent', { preprocessor: 'test/preproc' }).then(actual => {
-      expect(actual.slides).toEqual('' +
-        '<section  data-markdown><script type="text/template"># Slide A\n\ncontent\n\n</script></section>' +
-        '<section  data-markdown><script type="text/template">\n# Slide B\n\ncontent</script></section>');
-    });
+    render
+      .parseSlides('# Slide A\n\ncontent\n\n# Slide B\n\ncontent', { preprocessor: 'test/preproc' })
+      .then(actual => {
+        expect(actual.slides).toEqual(
+          '' +
+            '<section  data-markdown><script type="text/template"># Slide A\n\ncontent\n\n</script></section>' +
+            '<section  data-markdown><script type="text/template">\n# Slide B\n\ncontent</script></section>'
+        );
+      });
   });
-
 });


### PR DESCRIPTION
[OpenGraph](http://ogp.me) metadata allows more attractive rendering output of links to static slide decks when they are shared in social media sites.

Metada is generated only when ``--absolute-url`` command line option is used to define eventual hosted url of the slide deck. This is used to create canonical url and ``og:image`` url.

Featured slide snapshot is captured during builds to be used as ``og:image``. Capturing is done using Puppeteer with similar approach than PDF generation.

Snapshot is stored in static build directory with filename `featured-slide.jpg`.

Captured slide could be selected by providing ``--featured-slide`` command line option, by default the first slide of the deck will be used.

Example slide deck with generated metadata: https://iiska.gitlab.io/elm-talk/

![reveal-md-pr-pic](https://user-images.githubusercontent.com/38529/41487675-3b09508c-70f2-11e8-970b-ffe0a7cb0fe2.png)


Functionality for providing Chromium arguments for Puppeteer is also included to enable running static builds capturing featured slide snapshots in CI environments. [Puppeteer troubleshooting](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md) documentation contains more details about this workaround.
