### PR TITLE
Replaces open with opn to address https://nodesecurity.io/advisories/663

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -7,7 +7,7 @@ const favicon = require('serve-favicon');
 const url = require('url');
 const _ = require('lodash');
 const liveReload = require('livereload');
-const open = require('open');
+const opn = require('opn');
 const { renderMarkdown, renderMarkdownFileListing } = require('./render');
 const { getOptions } = require('./options');
 
@@ -53,7 +53,7 @@ module.exports = function startServer(options, cb) {
   if (!options.print) {
     console.log(`Reveal-server started at ${host}`);
     if (!options.disableAutoOpen) {
-      open(initialUrl);
+      opn(initialUrl);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "livereload": "0.7.0",
     "lodash": "4.17.10",
     "mustache": "2.3.0",
-    "open": "0.0.5",
+    "opn": "5.3.0",
     "reveal.js": "3.6.0",
     "serve-favicon": "2.5.0",
     "yaml-front-matter": "4.0.0"


### PR DESCRIPTION
Replaces [open](https://github.com/pwnall/node-open) with [opn](https://github.com/sindresorhus/opn) to address this the following scary-sounding warning from `npm audit`:

```
                       === npm audit security report ===

┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Critical      │ Command Injection                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ open                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ No patch available                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ reveal-md                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ reveal-md > open                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/663                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 1 critical severity vulnerability in 593 scanned packages
```

This also adds a `package-lock.json`. If you prefer not to have a package-lock as part of reveal-md, I'm happy to amend the commit to remove it.

All existing tests pass, but since none of the existing tests tested `open`, this was expected. Neither `open` nor `opn` have proper automated tests (see: https://github.com/pwnall/node-open/blob/master/test/open.js and https://github.com/sindresorhus/opn/blob/master/test.js) because you can't really easily verify anything more than not returning an error.

Manually tested auto-open of browser on OS X.