### PR TITLE
adds usage of puppeteerLaunchArgs to print feature

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -34,7 +34,7 @@ module.exports = function print(options) {
     console.log(`Attempting to print "${initialPath}?print-pdf" to filename "${pdfFilename}.pdf" as PDF.`);
 
     return puppeteer
-      .launch()
+      .launch(options.puppeteerLaunchArgs ? { args: options.puppeteerLaunchArgs.split(' ') } : {})
       .then(browser =>
         browser.newPage().then(page => {
           return page.goto(`${url}?print-pdf`, { waitUntil: 'load' }).then(() => {


### PR DESCRIPTION
This allows to print slide pdfs in environments where you might have to launch chrome with '--no-sandbox'.
This is for example the case if you are running as root inside a container.