### PR TITLE
Add the ability to change assets directory

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,6 +21,7 @@ program
   .option('    --highlight-theme <theme>', `Highlight theme [default: ${defaults.highlightTheme}]`)
   .option('    --css <files>', 'CSS files to inject into the page')
   .option('    --scripts <files>', 'Scripts to inject into the page')
+  .option('    --assets-dir <dirname>', 'Defines assets directory name [default: _assets]')
   .option('    --preprocessor <script>', 'Markdown preprocessor script')
   .option('    --template <filename>', 'Template file for reveal.js')
   .option('    --listing-template <filename>', 'Template file for listing')

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -4,6 +4,7 @@
   "host": "localhost",
   "scripts": [],
   "css": [],
+  "assetsDir": "_assets",
   "preprocessor": null,
   "port": 1948,
   "print": false,

--- a/lib/options.js
+++ b/lib/options.js
@@ -18,6 +18,7 @@ const optionList = [
   'listingTemplate',
   'scripts',
   'css',
+  'assetsDir',
   'separator',
   'static',
   'staticDirs',
@@ -71,6 +72,7 @@ defaults.templateListing = () => fs.readFileSync(defaults.templateListingPath).t
 defaults.revealOptionsStr = () => JSON.stringify(revealOptions);
 defaults.themeUrl = 'css/theme/' + defaults.theme + '.css';
 defaults.highlightThemeUrl = '/css/highlight/' + defaults.highlightTheme + '.css';
+defaults.assetsDir = '_assets';
 defaults.preprocessorFn = markdown => Promise.resolve(markdown);
 
 const revealThemes = glob.sync('css/theme/*.css', { cwd: defaults.revealBasePath });

--- a/lib/options.js
+++ b/lib/options.js
@@ -72,7 +72,6 @@ defaults.templateListing = () => fs.readFileSync(defaults.templateListingPath).t
 defaults.revealOptionsStr = () => JSON.stringify(revealOptions);
 defaults.themeUrl = 'css/theme/' + defaults.theme + '.css';
 defaults.highlightThemeUrl = '/css/highlight/' + defaults.highlightTheme + '.css';
-defaults.assetsDir = '_assets';
 defaults.preprocessorFn = markdown => Promise.resolve(markdown);
 
 const revealThemes = glob.sync('css/theme/*.css', { cwd: defaults.revealBasePath });

--- a/lib/static.js
+++ b/lib/static.js
@@ -36,7 +36,7 @@ function embedImages(markdown, options) {
 
 module.exports = function renderStaticMarkup(options) {
   const { staticDir } = options;
-  const assetsDir = path.join(staticDir, '_assets');
+  const assetsDir = path.join(staticDir, options.assetsDir);
 
   const awaits = ['css', 'js', 'plugin', 'lib'].map(dir =>
     fs.copyAsync(path.join(options.revealBasePath, dir), path.join(staticDir, dir))


### PR DESCRIPTION
So I added the ability to change assets directory through `--assets-dir` option. It works only with `--static`, because there is no reason to change assets directory in "live view" mode. The default option is still `_assets`.

This resolves issue #207