### PR TITLE
Adds option for customizing the chromium executable used by puppeteer

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,7 +42,10 @@ program
     '    --absolute-url <url>',
     'Define url used for hosting static build. This is included in OpenGraph metadata. Only used with --static.'
   )
-  .option('    --puppeteer-launch-args <args>', 'Customize how Puppeteer launches Chromium. Needed for some CI setups.')
+  .option(
+    '    --puppeteer-launch-args <args>',
+    'Customize how Puppeteer launches Chromium. The arguments are specified as a space separated list (for example "--no-sandbox --disable-dev-shm-usage"). Needed for some CI setups.'
+  )
   .parse(process.argv);
 
 if (program.args.length > 2) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -46,6 +46,10 @@ program
     '    --puppeteer-launch-args <args>',
     'Customize how Puppeteer launches Chromium. The arguments are specified as a space separated list (for example "--no-sandbox --disable-dev-shm-usage"). Needed for some CI setups.'
   )
+  .option(
+    '    --puppeteer-chromium-executable <path>',
+    'Customize which Chromium executable puppeteer will launch. Allows to use a globally installed version of Chromium.'
+  )
   .parse(process.argv);
 
 if (program.args.length > 2) {

--- a/lib/featured-slide.js
+++ b/lib/featured-slide.js
@@ -35,7 +35,7 @@ module.exports = function snapshot(options) {
       const url = `http://${options.host}:${options.port}/${initialPath}${slideAnchor}`;
 
       return puppeteer
-        .launch(options.puppeteerLaunchArgs ? { args: options.puppeteerLaunchArgs.split(' ') } : {})
+        .launch(options.puppeteerLaunchConfig)
         .then(browser =>
           browser
             .newPage()

--- a/lib/options.js
+++ b/lib/options.js
@@ -29,7 +29,8 @@ const optionList = [
   'noPhantom',
   'featuredSlide',
   'absoluteUrl',
-  'puppeteerLaunchArgs'
+  'puppeteerLaunchArgs',
+  'puppeteerChromiumExecutable'
 ];
 
 const getAssetPath = asset => `_assets/${asset}`;
@@ -143,6 +144,12 @@ function parseOptions(options) {
     options.puppeteerLaunchConfig = {
       ...options.puppeteerLaunchConfig,
       args: options.puppeteerLaunchArgs.split(' ')
+    };
+  }
+  if (options.puppeteerChromiumExecutable) {
+    options.puppeteerLaunchConfig = {
+      ...options.puppeteerLaunchConfig,
+      executablePath: options.puppeteerChromiumExecutable
     };
   }
   return options;

--- a/lib/options.js
+++ b/lib/options.js
@@ -72,6 +72,7 @@ defaults.revealOptionsStr = () => JSON.stringify(revealOptions);
 defaults.themeUrl = 'css/theme/' + defaults.theme + '.css';
 defaults.highlightThemeUrl = '/css/highlight/' + defaults.highlightTheme + '.css';
 defaults.preprocessorFn = markdown => Promise.resolve(markdown);
+defaults.puppeteerLaunchConfig = {};
 
 const revealThemes = glob.sync('css/theme/*.css', { cwd: defaults.revealBasePath });
 
@@ -137,6 +138,12 @@ function parseOptions(options) {
   if (options.css) {
     options.cssPaths = getAssetPaths(options.css);
     options.cssSources = getAssetSourcePaths(options.css);
+  }
+  if (options.puppeteerLaunchArgs) {
+    options.puppeteerLaunchConfig = {
+      ...options.puppeteerLaunchConfig,
+      args: options.puppeteerLaunchArgs.split(' ')
+    };
   }
   return options;
 }

--- a/lib/print.js
+++ b/lib/print.js
@@ -33,7 +33,7 @@ module.exports = function print(options) {
     console.log(`Attempting to print "${initialPath}?print-pdf" to filename "${pdfFilename}.pdf" as PDF.`);
 
     return puppeteer
-      .launch(options.puppeteerLaunchArgs ? { args: options.puppeteerLaunchArgs.split(' ') } : {})
+      .launch(options.puppeteerLaunchConfig)
       .then(browser =>
         browser.newPage().then(page => {
           return page.goto(`${url}?print-pdf`, { waitUntil: 'load' }).then(() => {


### PR DESCRIPTION
Hi,

this adds an cli option to use a different chromium executable than the bundled one installed by puppeteer. It allows to use base images that already come with chrome preinstalled, as it is not easy to get the bundled chromium to run on alpine based images ([Run puppeteer in Docker](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker)).

The pull request also improves the puppeteer launch args handling as it is now done in one place instead of seperate handling for featured slides and printing.
It also improves the cli help texts for these options.