### PR TITLE
Ignore all node_modules folders when listing directories

### DIFF
--- a/lib/listing.js
+++ b/lib/listing.js
@@ -18,7 +18,7 @@ const renderListFile = async files => {
 module.exports = async (req, res) => {
   const list = glob.sync('**/*.md', {
     cwd: await getInitialDir(),
-    ignore: 'node_modules/**'
+    ignore: '**/node_modules/**'
   });
 
   const markup = await renderListFile(list);


### PR DESCRIPTION
I'm using `reveal-md` to show [the lectures of my web programming course](https://github.com/vefforritun/vef2-2019), it replaced a lot of fragile homemade scripts and works beautifully. Excellent work!

Most of the time I'm presenting and showing examples, where the examples live in sub directories. This causes the listing overview to read _all_ `.md` files in `node_modules` sub directories. This PR fixes that.