### PR TITLE
Remove white margins in exported PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ The PDF is generated using Puppeteer. Alternatively, append `?print-pdf` to the 
 browser (make sure to remove the `#/` or `#/1` hash). Then print the slides using the browser's (not the native) print
 dialog. This seems to work in Chrome.
 
+By default, paper size is set to match options in your [`reveal.json`](#revealjs-options) file, falling back to
+a default value 960x700 pixels. To override this behaviour, you can pass custom dimensions or format
+in a command line option `--print-size`:
+
+```bash
+reveal-md slides.md --print slides.pdf --print-size 1024x768 # in pixels when no unit is given
+reveal-md slides.md --print slides.pdf --print-size 210x297mm # valid units are: px, in, cm, mm
+reveal-md slides.md --print slides.pdf --print-size A4 # valid formats are: A0-A6, Letter, Legal, Tabloid, Ledger
+```
+
 In case of an error, please try the following:
 
 - Analyze debug output, e.g. `DEBUG=reveal-md reveal-md slides.md --print`

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -24,6 +24,7 @@ Options:
       --port <port>                           Port [default: 1948]
       --featured-slide <num>                  Capture snapshot from this slide (numbering starts from 1) and use it as og:image for static build. Defaults to first slide. Only used with --static.
       --absolute-url <url>                    Define url used for hosting static build. This is included in OpenGraph metadata. Only used with --static.
+      --print-size                            Paper size to use in exported PDF files
       --puppeteer-launch-args <args>          Customize how Puppeteer launches Chromium. The arguments are specified as a space separated list (for example --puppeteer-launch-args="--no-sandbox --disable-dev-shm-usage"). Needed for some CI setups.
       --puppeteer-chromium-executable <path>  Customize which Chromium executable puppeteer will launch. Allows to use a globally installed version of Chromium.
   -h, --help                                  output usage information

--- a/bin/reveal-md.js
+++ b/bin/reveal-md.js
@@ -20,7 +20,7 @@ const alias = {
 
 const argv = argsParser(process.argv.slice(2), { alias });
 
-const { version, static: isStatic, featuredSlide, print, disableAutoOpen } = argv;
+const { version, static: isStatic, featuredSlide, print, printSize, disableAutoOpen } = argv;
 
 const [isStartServer] = argv._;
 
@@ -37,7 +37,7 @@ updater({ pkg }).notify();
         await writeStatic();
         server.close();
       } else if (print) {
-        await exportPDF(initialUrl, print);
+        await exportPDF(initialUrl, print, printSize);
         server.close();
       } else if (!disableAutoOpen) {
         open(initialUrl);

--- a/lib/config.js
+++ b/lib/config.js
@@ -109,3 +109,18 @@ module.exports.getPuppeteerLaunchConfig = () => {
     executablePath: puppeteerChromiumExecutable || null
   };
 };
+
+module.exports.getPageOptions = printSize => {
+  if (printSize) {
+    const dimensions = printSize.match(/^([\d.]+)x([\d.]+)([a-z]*)$/);
+    if (dimensions) {
+      const [width, height, unit] = dimensions.slice(1);
+      return { width: `${width}${unit}`, height: `${height}${unit}` };
+    }
+    return { format: printSize };
+  } else if (revealConfig.width && revealConfig.height) {
+    return { width: revealConfig.width, height: revealConfig.height };
+  } else {
+    return { format: 'A4' };
+  }
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -121,6 +121,6 @@ module.exports.getPageOptions = printSize => {
   } else if (revealConfig.width && revealConfig.height) {
     return { width: revealConfig.width, height: revealConfig.height };
   } else {
-    return { format: 'A4' };
+    return { width: 960, height: 700 };
   }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -118,7 +118,7 @@ module.exports.getPageOptions = printSize => {
       return { width: `${width}${unit}`, height: `${height}${unit}` };
     }
     return { format: printSize };
-  } else if (revealConfig.width && revealConfig.height) {
+  } else if (revealConfig && revealConfig.width && revealConfig.height) {
     return { width: revealConfig.width, height: revealConfig.height };
   } else {
     return { width: 960, height: 700 };

--- a/lib/print.js
+++ b/lib/print.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const debug = require('debug')('reveal-md');
 const { revealBasePath } = require('./constants');
-const { getRevealOptions, getPuppeteerLaunchConfig } = require('./config');
+const { getPuppeteerLaunchConfig, getPageOptions } = require('./config');
 let puppeteer;
 
 try {
@@ -12,28 +12,12 @@ try {
   debug(err);
 }
 
-const getPageOptions = (revealOptions, printSize) => {
-  if (printSize) {
-    const dimensions = printSize.match(/^([\d.]+)x([\d.]+)([a-z]*)$/);
-    if (dimensions) {
-      const [width, height, unit] = dimensions.slice(1);
-      return { width: `${width}${unit}`, height: `${height}${unit}` };
-    }
-    return { format: printSize };
-  } else if (revealOptions.width && revealOptions.height) {
-    return { width: revealOptions.width, height: revealOptions.height };
-  } else {
-    return { format: 'A4' };
-  }
-};
-
 module.exports = async (initialUrl, print, printSize) => {
   if (!puppeteer) {
     return;
   }
 
   const puppeteerLaunchConfig = getPuppeteerLaunchConfig();
-  const revealOptions = getRevealOptions();
 
   const printPluginPath = path.join(revealBasePath, 'plugin', 'print-pdf', 'print-pdf.js');
 
@@ -49,9 +33,7 @@ module.exports = async (initialUrl, print, printSize) => {
     const page = await browser.newPage();
 
     const pdfOptions = { path: pdfFilename, printBackground: true };
-    Object.assign(pdfOptions, getPageOptions(revealOptions, printSize));
-
-    console.log(pdfOptions);
+    Object.assign(pdfOptions, getPageOptions(printSize));
 
     await page.goto(`${initialUrl}?print-pdf`, { waitUntil: 'load' });
     await page.pdf(pdfOptions);

--- a/lib/print.js
+++ b/lib/print.js
@@ -12,15 +12,17 @@ try {
   debug(err);
 }
 
-const getPageOptions = revealOptions => {
-  if (revealOptions.width && revealOptions.height) {
+const getPageOptions = (revealOptions, printSize) => {
+  if (printSize) {
+    return { format: printSize };
+  } else if (revealOptions.width && revealOptions.height) {
     return { width: revealOptions.width, height: revealOptions.height };
   } else {
     return { format: 'A4' };
   }
 };
 
-module.exports = async (initialUrl, print) => {
+module.exports = async (initialUrl, print, printSize) => {
   if (!puppeteer) {
     return;
   }
@@ -42,7 +44,7 @@ module.exports = async (initialUrl, print) => {
     const page = await browser.newPage();
 
     const pdfOptions = { path: pdfFilename, printBackground: true };
-    Object.assign(pdfOptions, getPageOptions(revealOptions));
+    Object.assign(pdfOptions, getPageOptions(revealOptions, printSize));
 
     await page.goto(`${initialUrl}?print-pdf`, { waitUntil: 'load' });
     await page.pdf(pdfOptions);

--- a/lib/print.js
+++ b/lib/print.js
@@ -14,6 +14,11 @@ try {
 
 const getPageOptions = (revealOptions, printSize) => {
   if (printSize) {
+    const dimensions = printSize.match(/^([\d.]+)x([\d.]+)([a-z]*)$/);
+    if (dimensions) {
+      const [width, height, unit] = dimensions.slice(1);
+      return { width: `${width}${unit}`, height: `${height}${unit}` };
+    }
     return { format: printSize };
   } else if (revealOptions.width && revealOptions.height) {
     return { width: revealOptions.width, height: revealOptions.height };
@@ -45,6 +50,8 @@ module.exports = async (initialUrl, print, printSize) => {
 
     const pdfOptions = { path: pdfFilename, printBackground: true };
     Object.assign(pdfOptions, getPageOptions(revealOptions, printSize));
+
+    console.log(pdfOptions);
 
     await page.goto(`${initialUrl}?print-pdf`, { waitUntil: 'load' });
     await page.pdf(pdfOptions);

--- a/lib/print.js
+++ b/lib/print.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const debug = require('debug')('reveal-md');
 const { revealBasePath } = require('./constants');
-const { getPuppeteerLaunchConfig } = require('./config');
+const { getRevealOptions, getPuppeteerLaunchConfig } = require('./config');
 let puppeteer;
 
 try {
@@ -12,12 +12,21 @@ try {
   debug(err);
 }
 
+const getPageOptions = revealOptions => {
+  if (revealOptions.width && revealOptions.height) {
+    return { width: revealOptions.width, height: revealOptions.height };
+  } else {
+    return { format: 'A4' };
+  }
+};
+
 module.exports = async (initialUrl, print) => {
   if (!puppeteer) {
     return;
   }
 
   const puppeteerLaunchConfig = getPuppeteerLaunchConfig();
+  const revealOptions = getRevealOptions();
 
   const printPluginPath = path.join(revealBasePath, 'plugin', 'print-pdf', 'print-pdf.js');
 
@@ -31,8 +40,12 @@ module.exports = async (initialUrl, print) => {
   try {
     const browser = await puppeteer.launch(puppeteerLaunchConfig);
     const page = await browser.newPage();
+
+    const pdfOptions = { path: pdfFilename, printBackground: true };
+    Object.assign(pdfOptions, getPageOptions(revealOptions));
+
     await page.goto(`${initialUrl}?print-pdf`, { waitUntil: 'load' });
-    await page.pdf({ path: `${pdfFilename}`, format: 'A4', printBackground: true });
+    await page.pdf(pdfOptions);
     await browser.close();
   } catch (err) {
     console.error(`Error while generating PDF for "${filename}"`);

--- a/test/getPageOptions.spec.js
+++ b/test/getPageOptions.spec.js
@@ -1,0 +1,20 @@
+const test = require('bron');
+const assert = require('assert').strict;
+const { getPageOptions } = require('../lib/config');
+
+test('should handle dimensions without units', () => {
+  const actual = getPageOptions('1024x768');
+  assert(actual.width === '1024');
+  assert(actual.height === '768');
+});
+
+test('should handle dimensions with units', () => {
+  const actual = getPageOptions('210x297mm');
+  assert(actual.width === '210mm');
+  assert(actual.height === '297mm');
+});
+
+test('should handle format name', () => {
+  const actual = getPageOptions('Letter');
+  assert(actual.format === 'Letter');
+});

--- a/test/getPageOptions.spec.js
+++ b/test/getPageOptions.spec.js
@@ -14,6 +14,12 @@ test('should handle dimensions with units', () => {
   assert(actual.height === '297mm');
 });
 
+test('should handle fractional dimensions', () => {
+  const actual = getPageOptions('8.5x11in');
+  assert(actual.width === '8.5in');
+  assert(actual.height === '11in');
+});
+
 test('should handle format name', () => {
   const actual = getPageOptions('Letter');
   assert(actual.format === 'Letter');


### PR DESCRIPTION
This PR changes default page size in exported PDFs to the same as configured slide size.
It also allows to set custom page format using `--print-size` CLI option.

Resolves #263.