### PR TITLE
Update puppeteer

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -105,7 +105,7 @@ module.exports.getPreprocessor = preprocessor => {
 module.exports.getPuppeteerLaunchConfig = () => {
   const { puppeteerLaunchArgs, puppeteerChromiumExecutable } = mergedConfig;
   return {
-    args: puppeteerLaunchArgs ? puppeteerLaunchArgs.split(' ') : null,
+    args: puppeteerLaunchArgs ? puppeteerLaunchArgs.split(' ') : [],
     executablePath: puppeteerChromiumExecutable || null
   };
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "yargs-parser": "13.1.1"
   },
   "optionalDependencies": {
-    "puppeteer": "1.3.0"
+    "puppeteer": "1.19.0"
   },
   "devDependencies": {
     "bron": "1.1.0",


### PR DESCRIPTION
Hi,

I updated Puppeteer to the latest version because of a [security vulnerability](https://www.npmjs.com/advisories/824) in the version used before.

It was also necessary to change default Puppeteer launch args to an empty array, because the library expected something you can call the method `every` on:
https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js#L252

By the way, @webpro, why don't you keep `package-lock.json` in the repository and all dependencies are specified by exact versions and not `^`/`~` matchers?