### PR TITLE
Add option to whitelist MD files for conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ Providing a directory will result in a stand-alone overview page with links to t
 reveal-md dir/ --static
 ```
 
+By default all `*.md` files in all subdirectories are included in the generated website. You can provide custom [glob pattern](https://github.com/isaacs/node-glob) using `--glob` parameter to generate slides only from some files:
+
+```console
+reveal-md dir/ --static --glob '**/slides.md'
+```
+
 Additional `--absolute-url` and `--featured-slide` parameters could be used to generate [OpenGraph](http://ogp.me)
 metadata enabling more attractive rendering for slide deck links when shared in some social sites.
 

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -15,6 +15,7 @@ Options:
       --preprocessor <script>                 Markdown preprocessor script
       --template <filename>                   Template file for reveal.js
       --listing-template <filename>           Template file for listing
+      --glob <pattern>                        Glob pattern to select markdown files for listing and conversion [default: **/*.md]
       --print [filename]                      Print to PDF file
       --static [dir]                          Export static html to directory [_static]. Incompatible with --print.
       --static-dirs <dirs>                    Extra directories to copy into static directory. Only used in conjunction with --static.

--- a/lib/config.js
+++ b/lib/config.js
@@ -48,6 +48,7 @@ module.exports.getStaticDir = () => (mergedConfig.static === true ? mergedConfig
 module.exports.getHost = () => mergedConfig.host;
 module.exports.getPort = () => mergedConfig.port;
 module.exports.getWatch = () => Boolean(mergedConfig.watch);
+module.exports.getSlidesGlob = () => mergedConfig.slidesGlob;
 
 module.exports.getOptions = () => mergedConfig;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -48,7 +48,7 @@ module.exports.getStaticDir = () => (mergedConfig.static === true ? mergedConfig
 module.exports.getHost = () => mergedConfig.host;
 module.exports.getPort = () => mergedConfig.port;
 module.exports.getWatch = () => Boolean(mergedConfig.watch);
-module.exports.getSlidesGlob = () => mergedConfig.slidesGlob;
+module.exports.getFilesGlob = () => mergedConfig.glob;
 
 module.exports.getOptions = () => mergedConfig;
 

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -14,5 +14,5 @@
   "theme": "black",
   "title": "reveal-md",
   "verticalSeparator": "\r?\n----\r?\n",
-  "slidesGlob": "**/*.md"
+  "glob": "**/*.md"
 }

--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -13,5 +13,6 @@
   "template": "template/reveal.html",
   "theme": "black",
   "title": "reveal-md",
-  "verticalSeparator": "\r?\n----\r?\n"
+  "verticalSeparator": "\r?\n----\r?\n",
+  "slidesGlob": "**/*.md"
 }

--- a/lib/listing.js
+++ b/lib/listing.js
@@ -1,6 +1,6 @@
 const glob = require('glob');
 const Mustache = require('mustache');
-const { getInitialDir, getOptions, getListingTemplate, getThemeUrl, getSlidesGlob } = require('./config');
+const { getInitialDir, getOptions, getListingTemplate, getThemeUrl, getFilesGlob } = require('./config');
 
 const renderListFile = async files => {
   const { title, listingTemplate, theme } = getOptions();
@@ -16,7 +16,7 @@ const renderListFile = async files => {
 };
 
 module.exports = async (req, res) => {
-  const list = glob.sync(getSlidesGlob(), {
+  const list = glob.sync(getFilesGlob(), {
     cwd: await getInitialDir(),
     ignore: '**/node_modules/**'
   });

--- a/lib/listing.js
+++ b/lib/listing.js
@@ -1,6 +1,6 @@
-const glob = require('glob');
 const Mustache = require('mustache');
 const { getInitialDir, getOptions, getListingTemplate, getThemeUrl, getFilesGlob } = require('./config');
+const { listFiles } = require('./util');
 
 const renderListFile = async files => {
   const { title, listingTemplate, theme } = getOptions();
@@ -16,11 +16,7 @@ const renderListFile = async files => {
 };
 
 module.exports = async (req, res) => {
-  const list = glob.sync(getFilesGlob(), {
-    cwd: await getInitialDir(),
-    ignore: '**/node_modules/**'
-  });
-
+  const list = listFiles(await getInitialDir(), getFilesGlob());
   const markup = await renderListFile(list);
 
   res.send(markup);

--- a/lib/listing.js
+++ b/lib/listing.js
@@ -1,6 +1,6 @@
 const glob = require('glob');
 const Mustache = require('mustache');
-const { getInitialDir, getOptions, getListingTemplate, getThemeUrl } = require('./config');
+const { getInitialDir, getOptions, getListingTemplate, getThemeUrl, getSlidesGlob } = require('./config');
 
 const renderListFile = async files => {
   const { title, listingTemplate, theme } = getOptions();
@@ -16,7 +16,7 @@ const renderListFile = async files => {
 };
 
 module.exports = async (req, res) => {
-  const list = glob.sync('**/*.md', {
+  const list = glob.sync(getSlidesGlob(), {
     cwd: await getInitialDir(),
     ignore: '**/node_modules/**'
   });

--- a/lib/static.js
+++ b/lib/static.js
@@ -4,7 +4,7 @@ const path = require('path');
 const glob = require('glob');
 const _ = require('lodash');
 const url = require('url');
-const { getOptions, getAssetsDir, getPath, getStaticDir, getSlideOptions, getSlidesGlob } = require('./config');
+const { getOptions, getAssetsDir, getPath, getStaticDir, getSlideOptions, getFilesGlob } = require('./config');
 const { isDirectory, parseYamlFrontMatter } = require('./util');
 const { revealBasePath, highlightThemePath } = require('./constants');
 const { renderFile } = require('./render');
@@ -76,7 +76,7 @@ const copyAssetsAndWriteFile = async (sourceDir, file, targetDir) => {
 
 const writeMarkupFiles = async (sourceDir, targetDir) => {
   if (await isDirectory(sourceDir)) {
-    const list = glob.sync(getSlidesGlob(), {
+    const list = glob.sync(getFilesGlob(), {
       cwd: sourceDir,
       ignore: 'node_modules/**'
     });

--- a/lib/static.js
+++ b/lib/static.js
@@ -1,11 +1,10 @@
 /* eslint-disable no-console */
 const fs = require('fs-extra');
 const path = require('path');
-const glob = require('glob');
 const _ = require('lodash');
 const url = require('url');
 const { getOptions, getAssetsDir, getPath, getStaticDir, getSlideOptions, getFilesGlob } = require('./config');
-const { isDirectory, parseYamlFrontMatter } = require('./util');
+const { isDirectory, parseYamlFrontMatter, listFiles } = require('./util');
 const { revealBasePath, highlightThemePath } = require('./constants');
 const { renderFile } = require('./render');
 const { renderListFile } = require('./listing');
@@ -76,10 +75,7 @@ const copyAssetsAndWriteFile = async (sourceDir, file, targetDir) => {
 
 const writeMarkupFiles = async (sourceDir, targetDir) => {
   if (await isDirectory(sourceDir)) {
-    const list = glob.sync(getFilesGlob(), {
-      cwd: sourceDir,
-      ignore: 'node_modules/**'
-    });
+    const list = listFiles(sourceDir, getFilesGlob());
     const listMarkup = await renderListFile(list.map(file => file.replace(/\.md$/, '.html')));
     return Promise.all(
       _.flatten([

--- a/lib/static.js
+++ b/lib/static.js
@@ -4,7 +4,7 @@ const path = require('path');
 const glob = require('glob');
 const _ = require('lodash');
 const url = require('url');
-const { getOptions, getAssetsDir, getPath, getStaticDir, getSlideOptions } = require('./config');
+const { getOptions, getAssetsDir, getPath, getStaticDir, getSlideOptions, getSlidesGlob } = require('./config');
 const { isDirectory, parseYamlFrontMatter } = require('./util');
 const { revealBasePath, highlightThemePath } = require('./constants');
 const { renderFile } = require('./render');
@@ -76,7 +76,7 @@ const copyAssetsAndWriteFile = async (sourceDir, file, targetDir) => {
 
 const writeMarkupFiles = async (sourceDir, targetDir) => {
   if (await isDirectory(sourceDir)) {
-    const list = glob.sync('**/*.md', {
+    const list = glob.sync(getSlidesGlob(), {
       cwd: sourceDir,
       ignore: 'node_modules/**'
     });

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@ const path = require('path');
 const _ = require('lodash');
 const { promisify } = require('util');
 const yamlFrontMatter = require('yaml-front-matter');
+const glob = require('glob');
 
 const stat = promisify(fs.stat);
 
@@ -30,4 +31,11 @@ module.exports.parseYamlFrontMatter = content => {
     yamlOptions: _.omit(document, '__content'),
     markdown: document.__content || content
   };
+};
+
+module.exports.listFiles = (workingDir, globPattern) => {
+  return glob.sync(globPattern, {
+    cwd: workingDir,
+    ignore: '**/node_modules/**'
+  });
 };

--- a/test/fixtures/a.md
+++ b/test/fixtures/a.md
@@ -1,0 +1,15 @@
+Foo
+
+Note: test note
+
+---
+
+Bar
+
+----
+
+Sub Bar
+
+---
+
+The End.

--- a/test/fixtures/slides.md
+++ b/test/fixtures/slides.md
@@ -1,0 +1,1 @@
+Slides.md file

--- a/test/fixtures/sub/c.md
+++ b/test/fixtures/sub/c.md
@@ -1,0 +1,26 @@
+---
+title: Foobar
+separator: <!--s-->
+verticalSeparator: <!--v-->
+theme: solarized
+revealOptions:
+    transition: fade
+---
+Foo
+
+Note: test note
+
+<!--s-->
+
+# Bar
+
+<!--v-->
+
+Sub Bar 
+
+* Frag 1 <!-- .element: class="fragment" -->
+* Frag 2 <!-- .element: class="fragment" -->
+
+<!--s-->
+
+The End.

--- a/test/fixtures/sub/slides.md
+++ b/test/fixtures/sub/slides.md
@@ -1,0 +1,1 @@
+Slides.md file in subfolder

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,0 +1,19 @@
+const test = require('bron');
+const assert = require('assert').strict;
+const { join } = require('path');
+const { listFiles } = require('../lib/util');
+const { getFilesGlob } = require('../lib/config');
+
+const FIXTURES_DIR = join(__dirname, 'fixtures');
+
+test('listFiles should list all MD files with default config', async () => {
+  const expected = ['a.md', 'slides.md', 'sub/c.md', 'sub/slides.md'];
+  const actual = listFiles(FIXTURES_DIR, getFilesGlob());
+  assert.deepEqual(expected, actual);
+});
+
+test('listFiles should list only files matching the glob', async () => {
+  const expected = ['slides.md', 'sub/slides.md'];
+  const actual = listFiles(FIXTURES_DIR, '**/slides.md');
+  assert.deepEqual(expected, actual);
+});


### PR DESCRIPTION
Hello, this is primarily a proposal based on my personal proof of concept. If you agree to include this feature, I will polish the PR to include tests and documentation.

My motivation: I have multiple MD files in subdirectories and I would like to convert all slides at once for shared assets and listing.  However, there are also some "meta" files like `README.md` which should not be processed by reveal-md. Currently all MD files are converted to HTML. Also if some subfolder contains e.g. `node_modules/` directory, reveal-md also processes MD files recursively in there, making the final listing pretty unusable.

Looking at the code, I noticed there's a hardcoded glob pattern for listing MD files for conversion as `**/*.md`, so I just exposed it for configuration as `slidesGlob` option. Now I can do e.g.:
```console
reveal-md --slides-glob='**/slides.md' --static
```
to convert only `slides.md` files.

I am not quite sure about the `slidesGlob` name, so feel free to propose something else.