### PR TITLE
Copy assets specified in YAML Front matter for a static build

### DIFF
--- a/demo/e.md
+++ b/demo/e.md
@@ -1,0 +1,9 @@
+---
+title: "Custom Options With Frontmatter"
+theme: night
+highlightTheme: tomorrow-night-bright
+---
+
+```js
+console.log('Hello world!')
+```

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const _ = require('lodash');
-const yamlFrontMatter = require('yaml-front-matter');
-const { md } = require('./util');
+const { md, parseYamlFrontMatter } = require('./util');
 const fs = require('fs-extra');
 const Mustache = require('mustache');
 const defaults = require('./defaults.json');
@@ -20,14 +19,6 @@ const {
 
 const slidifyProps = ['attributes', 'notesSeparator', 'separator', 'verticalSeparator'];
 const getSlidifyOptions = context => _.pick(context, slidifyProps);
-
-const parseYamlFrontMatter = content => {
-  const document = yamlFrontMatter.loadFront(content.replace(/^\uFEFF/, ''));
-  return {
-    yamlOptions: _.omit(document, '__content'),
-    markdown: document.__content || content
-  };
-};
 
 const slidify = (markdown, slidifyOptions = _.pick(defaults, slidifyProps)) => {
   return md.slidify(markdown, slidifyOptions);

--- a/lib/static.js
+++ b/lib/static.js
@@ -71,7 +71,7 @@ const copyAssetsAndWriteFile = async (sourceDir, file, targetDir) => {
   const markup = await renderFile(path.join(sourceDir, file), { base });
   awaits.push(write(path.join(targetDir, file).replace(/\.md$/, '.html'), markup));
   awaits.push(featuredSlide(file, path.join(targetDir, path.dirname(file))));
-  return awaits;
+  return Promise.all(awaits);
 };
 
 const writeMarkupFiles = async (sourceDir, targetDir) => {
@@ -84,7 +84,7 @@ const writeMarkupFiles = async (sourceDir, targetDir) => {
     return Promise.all(
       _.flatten([
         write(path.join(targetDir, 'index.html'), listMarkup),
-        ...list.map(async file => copyAssetsAndWriteFile(sourceDir, file, targetDir))
+        ...list.map(file => copyAssetsAndWriteFile(sourceDir, file, targetDir))
       ])
     );
   } else {

--- a/lib/static.js
+++ b/lib/static.js
@@ -4,8 +4,8 @@ const path = require('path');
 const glob = require('glob');
 const _ = require('lodash');
 const url = require('url');
-const { getOptions, getAssetsDir, getPath, getStaticDir } = require('./config');
-const { isDirectory } = require('./util');
+const { getOptions, getAssetsDir, getPath, getStaticDir, getSlideOptions } = require('./config');
+const { isDirectory, parseYamlFrontMatter } = require('./util');
 const { revealBasePath, highlightThemePath } = require('./constants');
 const { renderFile } = require('./render');
 const { renderListFile } = require('./listing');
@@ -33,9 +33,31 @@ const link = (source, target) => {
   return fs.ensureSymlink(source, target);
 };
 
-const copyImagesAndWriteFile = async (sourceDir, file, targetDir) => {
+const copyAssetsFromOptions = function(markdown) {
+  const { yamlOptions } = parseYamlFrontMatter(markdown.toString());
+  const options = getSlideOptions(yamlOptions);
+  const staticDir = getStaticDir();
+  const awaits = [
+    cp(
+      path.join(highlightThemePath, options.highlightTheme + '.css'),
+      path.join(staticDir, 'css', 'highlight', options.highlightTheme + '.css')
+    )
+  ];
+  return awaits.concat(
+    _.flow(
+      _.flatten,
+      _.compact,
+      _.partialRight(_.map, asset => cp(asset, path.join(staticDir, getAssetsDir(), asset)))
+    )([
+      typeof options.scripts === 'string' ? options.scripts.split(',') : options.scripts,
+      typeof options.css === 'string' ? options.css.split(',') : options.css
+    ])
+  );
+};
+
+const copyAssetsAndWriteFile = async (sourceDir, file, targetDir) => {
   const markdown = await fs.readFile(path.join(sourceDir, file));
-  const awaits = [];
+  const awaits = copyAssetsFromOptions(markdown);
   let image;
   while ((image = mdImageRE.exec(markdown))) {
     const [, , imgPath] = image;
@@ -62,30 +84,23 @@ const writeMarkupFiles = async (sourceDir, targetDir) => {
     return Promise.all(
       _.flatten([
         write(path.join(targetDir, 'index.html'), listMarkup),
-        ...list.map(async file => copyImagesAndWriteFile(sourceDir, file, targetDir))
+        ...list.map(async file => copyAssetsAndWriteFile(sourceDir, file, targetDir))
       ])
     );
   } else {
     const fileName = path.basename(sourceDir);
     const markupName = fileName.replace(/\.md$/, '.html');
-    await copyImagesAndWriteFile(path.dirname(sourceDir), fileName, targetDir);
+    await copyAssetsAndWriteFile(path.dirname(sourceDir), fileName, targetDir);
     return link(path.join(targetDir, markupName), path.join(targetDir, 'index.html'));
   }
 };
 
 module.exports = async () => {
   const options = getOptions();
-  const { highlightTheme } = options;
   const staticDir = getStaticDir();
-  const assetsDir = getAssetsDir();
 
   await Promise.all(
     ['css', 'js', 'plugin', 'lib'].map(dir => cp(path.join(revealBasePath, dir), path.join(staticDir, dir)))
-  );
-
-  await cp(
-    path.join(highlightThemePath, highlightTheme + '.css'),
-    path.join(staticDir, 'css', 'highlight', highlightTheme + '.css')
   );
 
   const staticDirs = typeof options.staticDirs === 'string' ? options.staticDirs.split(',') : options.staticDirs;
@@ -94,14 +109,6 @@ module.exports = async () => {
   );
 
   await writeMarkupFiles(getPath(), staticDir);
-
-  const assets = _.compact(
-    _.flatten([
-      typeof options.scripts === 'string' ? options.scripts.split(',') : options.scripts,
-      typeof options.css === 'string' ? options.css.split(',') : options.css
-    ])
-  );
-  await Promise.all(assets.map(async asset => cp(asset, path.join(staticDir, assetsDir, asset))));
 
   console.log(`Wrote static site to ${staticDir}`);
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 const { promisify } = require('util');
+const yamlFrontMatter = require('yaml-front-matter');
 
 const stat = promisify(fs.stat);
 
@@ -22,3 +23,11 @@ module.exports.isFile = _.memoize(async dir => {
   const stats = await stat(path.resolve(dir));
   return stats.isFile();
 });
+
+module.exports.parseYamlFrontMatter = content => {
+  const document = yamlFrontMatter.loadFront(content.replace(/^\uFEFF/, ''));
+  return {
+    yamlOptions: _.omit(document, '__content'),
+    markdown: document.__content || content
+  };
+};


### PR DESCRIPTION
This is a follow-up to #265 which got recently closed.

I was unable to reproduce the issue with linking. I am on macOS 10.15 with Node v10.17.0 (I have also tried v12.12.0 with the same result).

My suspicion is that maybe we are not awaiting for the whole array of promises from `copyAssetsAndWriteFile` to resolve, so I have added `Promise.all` around the return value. Other than that I have rebased the PR, removed unnecessary `async`, and added an example to `demo` folder. Most of the hard work has been already done by @lukaszkostrzewa, I would just like to help to get this fix through.