### PR TITLE
Fix usage of theme URL

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -59,7 +59,7 @@ module.exports.getRevealOptions = options => {
   return _.defaults({}, options, revealConfig);
 };
 
-module.exports.getThemeUrl = theme => {
+module.exports.getThemeUrl = (theme, base = '') => {
   const parsedUrl = url.parse(theme);
   if (parsedUrl.host) {
     return theme;
@@ -67,7 +67,7 @@ module.exports.getThemeUrl = theme => {
     const revealTheme = revealThemes.find(
       themePath => path.basename(themePath).replace(path.extname(themePath), '') === theme
     );
-    return revealTheme || getAssetPath(theme);
+    return revealTheme ? base + '/' + revealTheme : getAssetPath(theme);
   }
 };
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -29,7 +29,7 @@ const render = async (input, extraOptions = {}) => {
   const options = Object.assign(getSlideOptions(yamlOptions), extraOptions);
 
   const { title } = options;
-  const themeUrl = getThemeUrl(options.theme);
+  const themeUrl = getThemeUrl(options.theme, options.base);
   const highlightThemeUrl = getHighlightThemeUrl(options.highlightTheme);
   const revealOptions = Object.assign({}, getRevealOptions(options.revealOptions), yamlOptions.revealOptions);
   const scriptPaths = getScriptPaths(options.scripts, options.assetsDir);

--- a/lib/template/listing.html
+++ b/lib/template/listing.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Directory Listing</title>
-    <link rel="stylesheet" href="{{{base}}}/{{{themeUrl}}}" id="theme" />
+    <link rel="stylesheet" href="{{{themeUrl}}}" id="theme" />
     <style type="text/css">
       body {
         margin: 1em;

--- a/lib/template/reveal.html
+++ b/lib/template/reveal.html
@@ -12,7 +12,7 @@
     <meta property="og:url" content="{{{absoluteUrl}}}" />
     {{/absoluteUrl}}
     <link rel="stylesheet" href="{{{base}}}/css/reveal.css" />
-    <link rel="stylesheet" href="{{{base}}}/{{{themeUrl}}}" id="theme" />
+    <link rel="stylesheet" href="{{{themeUrl}}}" id="theme" />
     <link rel="stylesheet" href="{{{base}}}{{{highlightThemeUrl}}}" />
     <link rel="stylesheet" href="{{{base}}}/css/print/{{#print}}pdf{{/print}}{{^print}}paper{{/print}}.css" type="text/css" media="print" />
     {{#cssPaths}}

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -55,6 +55,11 @@ test('should render alternate theme stylesheet', async () => {
   assert(actual.includes('<link rel="stylesheet" href="/css/theme/white.css"'));
 });
 
+test('should render remote theme stylesheet', async () => {
+  const actual = await render('', { theme: 'https://example.org/style.css' });
+  assert(actual.includes('<link rel="stylesheet" href="https://example.org/style.css"'));
+});
+
 test('should render root-based domain-less links for static markup', async () => {
   const actual = await render('', { static: true, base: '.' });
   assert.equal(actual.match(/href="\.\//g).length, 4);


### PR DESCRIPTION
The [documentation](https://github.com/webpro/reveal-md#theme) states themes can be referenced by URL, which seems to have been broken since the feature was implemented in #66. This PR fixes this for the option `theme`, but not `highlightTheme`.

Currently the template renders the theme with an URL incorrectly as `href="/https://example.org/style.css"`.