### PR TITLE
Add docker automation

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,14 @@
+name: Docker Image CI
+
+on: [push]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -5,10 +5,15 @@ on: [push]
 jobs:
 
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Publish
+      uses: jerray/publish-docker-action@v1.0.3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        auto_tag: true


### PR DESCRIPTION
This PR brings automatic image publication to docker.

This is implemented with https://github.com/jerray/publish-docker-action, which provides a simple way to publish tagged images on dockerhub.

I ran this automation in my fork and by default it produced this image (tagged by the branch name which is default):

https://hub.docker.com/repository/docker/davidovich/reveal-md

@webpro when merged, you should add your dockerhub username and password (in your github repository settings->secrets), and I believe that your account on dockerhub differs, so add also a 

```yaml
repository: webpronl/reveal-md
```

like so: 
```
    - name: Publish
      uses: jerray/publish-docker-action@v1.0.3
      with:
        username: ${{ secrets.DOCKER_USERNAME }}
        password: ${{ secrets.DOCKER_PASSWORD }}
        repository: webpronl/reveal-md
        auto_tag: true 
```

closes #301