### PR TITLE
add SIGINT handler for properly closing reveal-md

### DIFF
--- a/bin/reveal-md.js
+++ b/bin/reveal-md.js
@@ -44,6 +44,11 @@ updater({ pkg }).notify();
       } else {
         [server, initialUrl] = await startServer();
         !disableAutoOpen && open(initialUrl);
+        process.on('SIGINT', () => {
+          console.log('Received SIGINT. Closing Gracefully.');
+          server.close();
+          process.exit(128);
+        })
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
This also allows correctly exiting the docker container when
using docker run.

fixes #307 