### PR TITLE
demo references a.md with wrong depth

### DIFF
--- a/demo/sub/deep/d.md
+++ b/demo/sub/deep/d.md
@@ -4,7 +4,7 @@
 * [Chapter 2a](#/2)
 * [Chapter 2b](#/2/1)
 * [Chapter 3](#/3)
-* [Entirely different deck](../../a.md)
+* [Entirely different deck](../../../a.md)
 
 ---
 


### PR DESCRIPTION
When run, the demo folder contains a dangling link to `a.md`. This is caused by a wrong relative depth.