### PR TITLE
Fix Listing With No Stylesheet

### DIFF
--- a/lib/template/listing.html
+++ b/lib/template/listing.html
@@ -4,15 +4,6 @@
     <meta charset="utf-8" />
     <title>Directory Listing</title>
     <link rel="stylesheet" href="{{{themeUrl}}}" id="theme" />
-    <style type="text/css">
-      body {
-        margin: 1em;
-      }
-      a {
-        color: white;
-        display: block;
-      }
-    </style>
   </head>
 
   <body>


### PR DESCRIPTION
If `themeUrl` is not passed, the stylesheet will make all link text white...on a white background.  Removing the styling so it won't unintentially override styles passed through `themeUrl`