### PR TITLE
don't copy if md is named index

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -83,7 +83,11 @@ const writeMarkupFiles = async (sourceDir, targetDir) => {
     const fileName = path.basename(sourceDir);
     const markupName = fileName.replace(/\.md$/, '.html');
     await copyAssetsAndWriteFile(path.dirname(sourceDir), fileName, targetDir);
-    return cp(path.join(targetDir, markupName), path.join(targetDir, 'index.html'));
+    if (markupName !== 'index.html') {
+      return cp(path.join(targetDir, markupName), path.join(targetDir, 'index.html'));
+    }
+
+    return Promise.resolve();
   }
 };
 


### PR DESCRIPTION
I use `index.md` for my top level markdown and I started getting the error
```
❏ .site/index.html → .site/index.html
Error: Source and destination must not be the same.
```
after https://github.com/webpro/reveal-md/blob/841df3bfc9b20a6239db78cd3c011a564c427f32/lib/static.js#L86 was changed from link to cp.

This avoids the cp in this case.