### PR TITLE
Manage favicon and custom favicon in static build

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -4,7 +4,7 @@ const path = require('path');
 const _ = require('lodash');
 const url = require('url');
 const { getOptions, getAssetsDir, getPath, getStaticDir, getSlideOptions, getFilesGlob } = require('./config');
-const { isDirectory, parseYamlFrontMatter, listFiles } = require('./util');
+const { isDirectory, isFile, parseYamlFrontMatter, listFiles } = require('./util');
 const { revealBasePath, highlightThemePath } = require('./constants');
 const { renderFile } = require('./render');
 const { renderListFile } = require('./listing');
@@ -99,6 +99,10 @@ module.exports = async () => {
   );
 
   await writeMarkupFiles(getPath(), staticDir);
+
+  const faviconPath = path.join(process.cwd(), 'favicon.ico');
+  const hasFavicon = (await fs.pathExists(faviconPath)) && isFile(faviconPath);
+  await cp(hasFavicon ? faviconPath : path.join(__dirname, 'favicon.ico'), path.join(staticDir, 'favicon.ico'));
 
   console.log(`Wrote static site to ${staticDir}`);
 };

--- a/lib/template/reveal.html
+++ b/lib/template/reveal.html
@@ -11,6 +11,7 @@
     <meta property="og:image" content="{{{absoluteUrl}}}/featured-slide.jpg" />
     <meta property="og:url" content="{{{absoluteUrl}}}" />
     {{/absoluteUrl}}
+    <link rel="shortcut icon" href="{{{base}}}/favicon.ico"/>
     <link rel="stylesheet" href="{{{base}}}/dist/reveal.css" />
     <link rel="stylesheet" href="{{{themeUrl}}}" id="theme" />
     <link rel="stylesheet" href="{{{base}}}{{{highlightThemeUrl}}}" />

--- a/test/render.spec.js
+++ b/test/render.spec.js
@@ -56,7 +56,7 @@ test('should render remote theme stylesheet', async () => {
 
 test('should render root-based domain-less links for static markup', async () => {
   const actual = await render('', { static: true, base: '.' });
-  assert.equal(actual.match(/href="\.\//g).length, 3);
+  assert.equal(actual.match(/href="\.\//g).length, 4);
   assert.equal(actual.match(/src="\.\//g).length, 6);
 });
 
@@ -103,4 +103,9 @@ test('should merge revealOptions from front matter and local options', async () 
   const actual = await render('---\nrevealOptions:\n  width: 300\n  height: 500\n---\nSlide', { revealOptions });
   const expected = JSON.stringify(Object.assign({}, revealOptions, { width: 300, height: 500 }));
   assert(actual.includes(`var options = extend(defaultOptions, ${expected}, queryOptions);`));
+});
+
+test('should render correct favicon', async () => {
+  const actual = await render('', { static: true, base: '.' });
+  assert(actual.includes(`<link rel="shortcut icon" href="./favicon.ico"/>`));
 });


### PR DESCRIPTION
Hello,

The [custom favicon](https://github.com/webpro/reveal-md#custom-favicon) work great in server mode however the favicon doesn't work in static build.

I use the same logic, take the favicon.ico at the root if it exists, otherwise use the default favicon.ico. 
