### PR TITLE
Fix faviconPath

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -111,7 +111,7 @@ module.exports = async () => {
 
   await writeMarkupFiles(getPath(), staticDir);
 
-  const faviconPath = path.join(process.cwd(), 'favicon.ico');
+  const faviconPath = path.join(process.cwd(), getPath(), 'favicon.ico');
   const hasFavicon = (await fs.pathExists(faviconPath)) && isFile(faviconPath);
   await cp(hasFavicon ? faviconPath : path.join(__dirname, 'favicon.ico'), path.join(staticDir, 'favicon.ico'));
 


### PR DESCRIPTION
According to the [README](https://github.com/webpro/reveal-md/blob/master/README.md#custom-favicon), the custom favicon should be placed in 

> the directory with the markdown files.

If I understand the code from `static.js` correctly, this path is the one from `getPath()` (which is also used as 1st argument when calling `writeMarkupFiles` in line 112). 

However, in the current code, the resulting path for `faviconPath` will always be the folder where the command is executed (`process.cwd()`).

With this Pull request, I propose to add `getPath()` to the list of paths to join in order to be able to copy the custom favicon.