### PR TITLE
Allow usage front-matter data in listing template

### DIFF
--- a/lib/listing.js
+++ b/lib/listing.js
@@ -1,18 +1,41 @@
 const Mustache = require('mustache');
 const path = require('path');
 const { getInitialDir, getOptions, getListingTemplate, getThemeUrl, getFilesGlob } = require('./config');
-const { listFiles } = require('./util');
+const { listFiles, parseYamlFrontMatter } = require('./util');
+const fs = require('fs-extra');
+
+
+const listFilesMeta = async (files) => {
+  const baseDir = await getInitialDir();
+
+  return Promise.all(files.map(async filePath => {
+    const markdownFilePath = path.join(baseDir, filePath).replace('.html', '.md');
+    const markdown = await fs.readFile(markdownFilePath);
+    let yamlOptions = {};
+    try {
+      yamlOptions = parseYamlFrontMatter(markdown.toString()).yamlOptions;
+    } catch(e) {
+      // there might be no front matter info in the file
+    }
+    return {
+      filePath,
+      yamlOptions
+    }
+  }));
+}
 
 const renderListFile = async files => {
   const { title, listingTemplate, theme } = getOptions();
   const template = await getListingTemplate(listingTemplate);
   const themeUrl = getThemeUrl(theme, '.');
+  const extendedFileRecords = await listFilesMeta(files);
   return Mustache.render(template, {
     base: '',
     themeUrl,
     title,
     filePaths: files,
-    fileNames: files.map(file => path.basename(file))
+    fileNames: files.map(file => path.basename(file)),
+    extendedFileRecords,
   });
 };
 

--- a/lib/template/listing.html
+++ b/lib/template/listing.html
@@ -8,9 +8,11 @@
 
   <body>
     <ul>
-      {{#filePaths}}
-      <li><a href="{{.}}">{{.}}</a></li>
-      {{/filePaths}}
+      {{#extendedFileRecords}}
+        {{#.}}
+          <li><a href="{{filePath}}" title="{{yamlOptions.title}}">{{filePath}}</a></li>
+        {{/.}}
+      {{/extendedFileRecords}}
     </ul>
   </body>
 </html>


### PR DESCRIPTION
Allows to use data from file meta (front matter) in listing template

https://github.com/webpro/reveal-md/issues/346