### PR TITLE
Switch to Alpine based container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim
+FROM node:lts-alpine
 
 COPY package.json package-lock.json /app/
 


### PR DESCRIPTION
Node's LTS slim container is based on Debian, which replaces vanilla
`/bin/sh` with `/bin/dash`.  This causes problems for things which are
expecting vanilla `/bin/sh`, like GitLab runner's docker executor.  An
easy solution is to simply replace Debian with something equally as
slim -- Alpine Linux.