### PR TITLE
Fix gitpitch URL since gitpitch.com is shutting down

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Many thanks to all [contributors][56]!
 [47]: https://github.com/jacksingleton/hacker-slides
 [48]: https://github.com/hakimel/reveal.js/wiki/Plugins,-Tools-and-Hardware#tools
 [49]: https://github.com/yjwen/org-reveal
-[50]: https://gitpitch.com
+[50]: https://github.com/gitpitch/gitpitch
 [51]: https://csinva.io/blog/misc/reveal_md_enhanced/readme.html
 [52]: https://ericmjl.github.io/blog/2020/1/18/create-your-own-auto-publishing-slides-with-reveal-md-and-travis-ci/
 [53]: https://mandieq.medium.com/beautiful-presentations-from-markdown-who-knew-it-could-be-so-easy-d279aa7f787a


### PR DESCRIPTION
Based on information from https://github.com/gitpitch/gitpitch

> March 1, 2021: Service on gitpitch.com has been shutdown permanently.

This PR change the URL for gitpitch to the gitpitch project instead of gitpitch.com