### PR TITLE
Fix YAML header example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ separator: <!--s-->
 verticalSeparator: <!--v-->
 theme: solarized
 revealOptions:
-transition: 'fade'
+  transition: 'fade'
 ---
 
 Foo


### PR DESCRIPTION
There was a bad indentation, that caused the `transition` property to not work.