### PR TITLE
bugfix: relative asset paths have to start with .

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -28,7 +28,7 @@ const mergedConfig = _.defaults({}, cliConfig, localConfig, defaults);
 const revealThemes = glob.sync('dist/theme/*.css', { cwd: revealBasePath });
 
 const getAssetPath = (asset, assetsDir = defaults.assetsDir, base) =>
-  isAbsoluteURL(asset) ? asset : `${base || ''}/${assetsDir}/${asset}`;
+  isAbsoluteURL(asset) ? asset : `.${base || ''}/${assetsDir}/${asset}`;
 
 const getAssetPaths = (assets, assetsDir, base) =>
   (typeof assets === 'string' ? assets.split(',') : assets).map(assetPath => getAssetPath(assetPath, assetsDir, base));


### PR DESCRIPTION
this fix was need to load custom css when exporting to static html