### PR TITLE
bugfix: search for images on rendered html files

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -11,8 +11,6 @@ const featuredSlide = require('./featured-slide');
 
 const files = new Set();
 
-const mdImageRE = /!\[[^\]]*\]\((.*?)\s*(["'](?:.*[^"'])["'])?\s*\)/g;
-
 const htmlImageRE = /<img.+src=["'](.+?)["'](?:.+?)>/g;
 
 const relativeDir = (from, to) => path.relative(from, to).replace(/^\.\./, '.');
@@ -61,17 +59,19 @@ const copyAssetsFromOptions = async function (markdown) {
 
 const copyAssetsAndWriteFile = async (sourceDir, file, targetDir) => {
   const markdown = await fs.readFile(path.join(sourceDir, file));
-  const awaits = await copyAssetsFromOptions(markdown);
+  const awaits = await copyAssetsFromOptions(markdown);  
+  const base = relativeDir(file, '.');
+  const markup = await renderFile(path.join(sourceDir, file), { base });
   let image;
-  while ((image = mdImageRE.exec(markdown) || htmlImageRE.exec(markdown))) {
+
+  while (image = htmlImageRE.exec(markup)) {
     const [, imgPath] = image;
     if (!isAbsoluteURL(imgPath)) {
       const relPath = path.join(path.dirname(file), imgPath);
       awaits.push(cp(path.join(sourceDir, relPath), path.join(targetDir, relPath)));
     }
   }
-  const base = relativeDir(file, '.');
-  const markup = await renderFile(path.join(sourceDir, file), { base });
+  
   awaits.push(write(path.join(targetDir, file).replace(/\.md$/, '.html'), markup));
   awaits.push(featuredSlide(file, path.join(targetDir, path.dirname(file))));
   return Promise.all(awaits);


### PR DESCRIPTION
This is needed since markdown files could be modified by preprocessor