### PR TITLE
Fix incorrect image copies [#408]

### DIFF
--- a/lib/static.js
+++ b/lib/static.js
@@ -69,7 +69,7 @@ const copyAssetsAndWriteFile = async (sourceDir, file, targetDir) => {
     const [, imgPath] = image;
     if (!isAbsoluteURL(imgPath)) {
       const relPath = path.join(path.dirname(file), imgPath);
-      awaits.push(cp(path.join(sourceDir, relPath), path.join(targetDir, relPath)));
+      awaits.push(cp(path.join(sourceDir, relPath), path.join(targetDir, relPath)).catch((err) => console.warn(err)));
     }
   }
 

--- a/lib/static.js
+++ b/lib/static.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const _ = require('lodash');
 const { getOptions, getAssetsDir, getPath, getStaticDir, getSlideOptions, getFilesGlob } = require('./config');
-const { isDirectory, isFile, parseYamlFrontMatter, getFilePaths, isAbsoluteURL } = require('./util');
+const { md, isDirectory, isFile, parseYamlFrontMatter, getFilePaths, isAbsoluteURL } = require('./util');
 const { revealBasePath, highlightThemePath } = require('./constants');
 const { renderFile } = require('./render');
 const { renderListFile } = require('./listing');
@@ -11,7 +11,6 @@ const featuredSlide = require('./featured-slide');
 
 const files = new Set();
 
-const mdImageRE = /!\[[^\]]*\]\((.*?)\s*(["'](?:.*[^"'])["'])?\s*\)/g;
 const htmlImageRE = /<img.+src=["'](.+?)["'](?:.+?)>/g;
 
 const relativeDir = (from, to) => path.relative(from, to).replace(/^\.\./, '.');
@@ -63,9 +62,10 @@ const copyAssetsAndWriteFile = async (sourceDir, file, targetDir) => {
   const awaits = await copyAssetsFromOptions(markdown);
   const base = relativeDir(file, '.');
   const markup = await renderFile(path.join(sourceDir, file), { base });
-  let image;
 
-  while ((image = mdImageRE.exec(markdown) || htmlImageRE.exec(markdown))) {
+  let image;
+  const html = md.marked(markdown.toString());
+  while (image = htmlImageRE.exec(html)) {
     const [, imgPath] = image;
     if (!isAbsoluteURL(imgPath)) {
       const relPath = path.join(path.dirname(file), imgPath);


### PR DESCRIPTION
This fix deals issues in #408.

Matching regex patterns that look like markdown or html image tags may fail when such patterns exist inside strings or code, such as:

```markdown
* Images below should not be included.
 
    ```html
    <p>
    This image doesn't exist, but it's okay because it's just source code.
    </p>
    
    <img src="weird-weird-image-path.jpg" alt="image 3" />
    ```
````

Moreover, currently any un-existing images during static run exits the program, which is not what a user may want.

This does the following:
* Instead of using regex match, transform into html and apply only to HTML image tags.
* catch any image copies, and ignore the error (prints out warning)

 
 
