### PR TITLE
Ensure rendered files are inside the initial directory

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -64,8 +64,12 @@ const renderFile = async (filePath, extraOptions) => {
 module.exports = async (req, res) => {
   const dir = await getInitialDir();
   const filePath = path.join(dir, decodeURIComponent(req.url).replace(/\?.*/, ''));
-  const markup = await renderFile(filePath);
-  res.send(markup);
+  if (filePath.startsWith(dir)) {
+    const markup = await renderFile(filePath);
+    res.send(markup);
+    return;
+  }
+  res.status(401).send("Forbidden: Only slides inside the initial directory can be accessed.");
 };
 
 module.exports.slidify = slidify;


### PR DESCRIPTION
This pull request adds a check to the rendering function to ensure that the provided path is within the initial directory. If it isn't, it responds with 401: Forbidden and a relevant message. The `filePath.startsWith` check should be sufficient because `path.join` (used to create `filePath`) and `path.resolve` (used to create `dir`) both normalize the resulting paths, so all `..` sections will be removed.

Closes #409.