### PR TITLE
Add patch for arbitrary file read

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -57,19 +57,30 @@ const render = async (input, extraOptions = {}) => {
 };
 
 const renderFile = async (filePath, extraOptions) => {
-  const content = await fs.readFile(filePath);
-  return render(content.toString(), extraOptions);
+  try{
+    const content = await fs.readFile(filePath);
+    return render(content.toString(), extraOptions);
+  }catch(e)
+  {
+    return render("File not found.", extraOptions)
+  }
 };
+
+function sanitize(entry)
+{
+  if(entry.includes(".."))
+  {
+    entry = sanitize(entry.replace("..",""))
+  }
+  return entry
+}
 
 module.exports = async (req, res) => {
   const dir = await getInitialDir();
-  const filePath = path.join(dir, decodeURIComponent(req.url).replace(/\?.*/, ''));
-  if (filePath.startsWith(dir)) {
-    const markup = await renderFile(filePath);
-    res.send(markup);
-    return;
-  }
-  res.status(401).send('Forbidden: Only slides inside the initial directory can be accessed.');
+  console.log(sanitize(decodeURIComponent(req.url)))
+  const filePath = path.join(dir, sanitize(decodeURIComponent(req.url)).replace(/\?.*/, ''));
+  const markup = await renderFile(filePath);
+  res.send(markup);
 };
 
 module.exports.slidify = slidify;

--- a/lib/render.js
+++ b/lib/render.js
@@ -77,7 +77,6 @@ function sanitize(entry)
 
 module.exports = async (req, res) => {
   const dir = await getInitialDir();
-  console.log(sanitize(decodeURIComponent(req.url)))
   const filePath = path.join(dir, sanitize(decodeURIComponent(req.url)).replace(/\?.*/, ''));
   const markup = await renderFile(filePath);
   res.send(markup);


### PR DESCRIPTION
This patch will do two things : 
- Add a try{}catch{} block to avoid the webserver to crash if someone try to reach a non-existent file (sort of DoS)
- Add a sanitize function to replace, after the urldecode function, all the ".." by nothing, and called himself if someone try to bypass the restriction