### PR TITLE
Print the initial Slide's URL on statup

### DIFF
--- a/bin/reveal-md.js
+++ b/bin/reveal-md.js
@@ -43,6 +43,7 @@ updater({ pkg }).notify();
         server.close();
       } else {
         [server, initialUrl] = await startServer();
+        console.log(`The slides are at ${initialUrl}`);
         !disableAutoOpen && open(initialUrl, { url: true });
         process.on('SIGINT', () => {
           console.log('Received SIGINT, closing gracefully.');


### PR DESCRIPTION
This message is helpful in cases where the URL is not automatically
opened. E.g. when running the application via Docker.
