### PR TITLE
Fix Docker metadata to push more tags

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -19,20 +19,28 @@ jobs:
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Docker meta
+
+      - name: Populate Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: webpronl/reveal-md
-          labels: |
-            org.opencontainers.image.licenses=MIT
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2023 Lars Kappert, https://webpro.nl <lars@webpro.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
I'm working with the Docker metadata action on an another project, and came back to this for reference.  Then however, I noticed that it was missing something.  This pull request tries to rectify that.  As it now only pushes full SemVer tags.

1. This change will now push the tags `6` and `6.0` too.
2. I added a license file so that GitHub were able to detect a repository license and it would autofill the metadata without some custom label.

For number 2, I'm looking into [license-year-updater](https://github.com/p3lim/license-year-updater) for updating it annually, but it's lacking the option to just bump the year in place instead of bumping the range.

---

Ed1t: I guess you need to trigger it for the login action to be able to use the login details?