### PR TITLE
Update documentation about location of reveal.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Markdown files. They'll be picked up automatically. Example:
 
 ### Reveal.js Options
 
-Define Reveal.js [options][37] in a `reveal.json` file that must be located at the root directory of the Markdown files.
+Define Reveal.js [options][37] in a `reveal.json` file at the project root.
 They'll be picked up automatically. Example:
 
 ```json


### PR DESCRIPTION
![image](https://github.com/webpro/reveal-md/assets/283419/013c1e09-61b2-4be9-bb9a-4c95d5a6dfc3)

The documentation mentions that the `reveal.json` file should be located `at the root directory of the Markdown files`. It doesn't appear to be the case, and it seems to pick it up from the project root instead.

This PR updates the documentation accordingly.

---

For context, I have my slides in `./slides/index.md`, and run `reveal-md` (installed locally) through `yarn run reveal-md ./slides/index.md --watch`.

- ✘ If I create `./slides/reveal.json`, it is not being used
- ✔ If I create `./reveal.json` (right next to `package.json`), it is correctly being used.
