### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      eslint:
+        patterns:
+          - 'eslint*'


### PR DESCRIPTION
Thought I could provide this.  Easier to keep track when new releases of Reveal.js is released.  Set it to weekly for now.

Enabled on my fork where you can see what is opened: https://github.com/MindTooth/reveal-md/pulls  Not that it's hitting a limit for npm.  So many more will open after some are merged.

Ed1t: also added a group for all eslint updates.