### PR TITLE
Added the date field to Mustache

### DIFF
--- a/lib/listing.js
+++ b/lib/listing.js
@@ -33,7 +33,8 @@ const renderListFile = async filePaths => {
     base: '',
     themeUrl,
     pageTitle: title,
-    files
+    files,
+    date: new Date().toISOString()
   });
 };
 

--- a/lib/template/listing.html
+++ b/lib/template/listing.html
@@ -11,10 +11,19 @@
       {{#files}}
       <li>
         <a href="{{filePath}}" title="{{title}}">
-          {{#title}}{{.}} ({{filePath}}){{/title}}{{^title}}{{filePath}}{{/title}}
+          {{#title}}
+            {{.}} ({{filePath}})
+          {{/title}}
+          {{^title}}
+            {{filePath}}
+          {{/title}}
         </a>
       </li>
       {{/files}}
     </ul>
+
+    <p>
+      Last update: {{date}}
+    </p>
   </body>
 </html>


### PR DESCRIPTION
This adds a date field to the listings page, which provides useful for automatic deployment (e.g. GitHub actions).