### PR TITLE
fix(print-pdf): wait untill all resources are loaded

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -38,7 +38,7 @@ export default async (initialUrl, print, printSize) => {
     const pdfOptions = { path: pdfFilename, printBackground: true };
     Object.assign(pdfOptions, getPageOptions(printSize));
 
-    await page.goto(`${initialUrl}?print-pdf`, { waitUntil: 'load' });
+    await page.goto(`${initialUrl}?print-pdf`, { waitUntil: 'networkidle0' });
     await page.pdf(pdfOptions);
     await browser.close();
   } catch (err) {


### PR DESCRIPTION
I encountered an issue with the loading of js assets and custom fonts when attempting to generate a PDF. This resulted in either empty or poorly formatted pdf. Upon investigation, I determined that the problem was related to the `waitUntil` option of Puppeteer's `goto()` method.

There are several options available for the `waitUntil` parameter, including `load`, `domcontentloaded`, `networkidle0`, and `networkidle2`. You can find detailed descriptions of these options [here](https://cloudlayer.io/blog/puppeteer-waituntil-options/) and a discussion in  [this GitHub issue](https://github.com/peterbe/minimalcss/issues/205#issuecomment-391389969).

I changed the `waitUntil` value to `networkidle0`, and this adjustment successfully resolved the problem, allowing the assets and fonts to load properly before generating pdf