### PR TITLE
Fixed regression on Windows systems

### DIFF
--- a/bin/reveal-md.js
+++ b/bin/reveal-md.js
@@ -2,7 +2,8 @@
 
 import argsParser from 'yargs-parser';
 import updater from 'update-notifier';
-import path from 'path';
+import path from 'node:path';
+import url from 'node:url';
 import { readFile } from 'node:fs/promises';
 import open from 'open';
 import startServer from '../lib/server.js';
@@ -10,7 +11,7 @@ import writeStatic from '../lib/static.js';
 import exportPDF from '../lib/print.js';
 import { loadJSON } from '../lib/util.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 const pkg = loadJSON(path.join(__dirname, '../package.json'));
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,16 +1,16 @@
-import path from 'node:path';
 import { createRequire } from 'node:module';
 import _ from 'lodash';
 import { readFile } from 'node:fs/promises';
 import * as fs from 'fs-extra';
 import parseArgs from 'yargs-parser';
+import path from 'node:path';
 import url from 'node:url';
 import { globSync } from 'glob';
 import { isDirectory, isFile, isAbsoluteURL, tryReadJson5Configs, loadJSON } from './util.js';
 
 const require = createRequire(import.meta.url);
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 export const defaults = loadJSON(path.join(__dirname, 'defaults.json'));
 export const revealBasePath = path.join(require.resolve('reveal.js'), '..', '..');
@@ -38,7 +38,7 @@ const cliConfig = parseArgs(process.argv.slice(2), {
 
 const mergedConfig = _.defaults({}, cliConfig, localConfig, defaults);
 
-const revealThemes = globSync('dist/theme/*.css', { cwd: revealBasePath });
+const revealThemes = globSync('dist/theme/*.css', { cwd: revealBasePath, posix: true });
 
 const getAssetPath = (asset, assetsDir = defaults.assetsDir, base) =>
   isAbsoluteURL(asset) ? asset : `${base || ''}/${assetsDir}/${asset}`;

--- a/lib/util.js
+++ b/lib/util.js
@@ -36,7 +36,8 @@ export const parseYamlFrontMatter = content => {
 export const getFilePaths = (workingDir, globPattern) => {
   return globSync(globPattern, {
     cwd: workingDir,
-    ignore: '**/node_modules/**'
+    ignore: '**/node_modules/**',
+    posix: true
   });
 };
 
@@ -50,7 +51,7 @@ export const loadJSON = filePath => {
 export const tryReadJson5Configs = (...possibleConfigFiles) => {
   for (const configFile of possibleConfigFiles) {
     try {
-      return json5.parse(fs.readFileSync(configFile));
+      return json5.parse(fs.readFileSync(configFile, 'utf8'));
     } catch (err) {
       if (err.code !== 'ENOENT') {
         throw err;

--- a/test/program.spec.js
+++ b/test/program.spec.js
@@ -1,12 +1,13 @@
 import test from 'node:test';
 import { strict as assert } from 'assert';
-import path from 'path';
+import path from 'node:path';
+import url from 'node:url';
 import { readFile } from 'node:fs/promises';
 import { exec as _exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { loadJSON } from '../lib/util.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 const pkg = loadJSON(path.join(__dirname, '../package.json'));
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,11 +1,12 @@
 import test from 'node:test';
 import { strict as assert } from 'assert';
-import { join } from 'path';
+import path from 'node:path';
+import url from 'node:url';
 import { getFilePaths } from '../lib/util.js';
 import { getFilesGlob } from '../lib/config.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
-const FIXTURES_DIR = join(__dirname, 'fixtures');
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
 test('should list all Markdown files with default config', async () => {
   const expected = ['a.md', 'slides.md', 'sub/c.md', 'sub/slides.md'];


### PR DESCRIPTION
I did all my development on Linux. Now I was experimenting on a Windows system and `reveal-md` failed on me. Apparently I introduced 2 bugs for Windows:

- The new `globSync` functions have gotten built in support for Windows paths, so I had to explicitly configure these to use POSIX paths.
- The code I used to simulate `__dirname` was not crossplatform, so I looked up a crossplatform solution and found https://nodejs.org/api/url.html#url_url_fileurltopath_url (inspired by https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules )

Sorry for the bug, I only realized it now ...