### PR TITLE
Reveal.js can now be updated to 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "lodash": "4.17.21",
         "mustache": "4.2.0",
         "open": "9.1.0",
-        "reveal.js": "4.5.0",
+        "reveal.js": "5.0.2",
         "serve-favicon": "2.5.0",
         "update-notifier": "7.0.0",
         "yaml-front-matter": "4.1.1",
@@ -6103,11 +6103,11 @@
       }
     },
     "node_modules/reveal.js": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.5.0.tgz",
-      "integrity": "sha512-Lx1hUWhJR7Y7ScQNyGt7TFzxeviDAswK2B0cn9RwbPZogTMRgS8+FTr+/12KNHOegjvWKH0H0EGwBARNDPTgWQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-5.0.2.tgz",
+      "integrity": "sha512-G5dhsr/2wormdrYPtZBfRamvnPrHc/8TtYVH3EpIzfMyKSiTprFwn61nFZbcmeK4iKKdLq2MMiiMNqlRmkBU4A==",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/rimraf": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "4.17.21",
     "mustache": "4.2.0",
     "open": "9.1.0",
-    "reveal.js": "4.5.0",
+    "reveal.js": "5.0.2",
     "serve-favicon": "2.5.0",
     "update-notifier": "7.0.0",
     "yaml-front-matter": "4.1.1",


### PR DESCRIPTION
Thanks to https://github.com/hakimel/reveal.js/issues/3517 we can call the markdown plugin again, thus we are able to update to Reveal.js 5.0.2.